### PR TITLE
Fix regex in parse_symbol_line

### DIFF
--- a/src/util/config.rs
+++ b/src/util/config.rs
@@ -70,7 +70,7 @@ pub fn apply_symbols_file(
 pub fn parse_symbol_line(line: &str, obj: &mut ObjInfo) -> Result<Option<ObjSymbol>> {
     static SYMBOL_LINE: Lazy<Regex> = Lazy::new(|| {
         Regex::new(
-            "^\\s*(?P<name>[^\\s=]+)\\s*=\\s*(?:(?P<section>[A-Za-z0-9.]+):)?(?P<addr>[0-9A-Fa-fXx]+);(?:\\s*//\\s*(?P<attrs>.*))?$",
+            "^\\s*(?P<name>.+?)\\s*=\\s*(?:(?P<section>[A-Za-z0-9.]+):)?(?P<addr>[0-9A-Fa-fXx]+);(?:\\s*//\\s*(?P<attrs>.*))?$",
         )
         .unwrap()
     });


### PR DESCRIPTION
There are some strange but valid symbols used in some of the internal D3D9 code that uses the `=` symbol. This regex change allows for the correct capture of those symbols.