### PR TITLE
Merge upstream decomp-toolkit v1.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
@@ -36,18 +36,12 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -60,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 dependencies = [
  "backtrace",
 ]
@@ -90,23 +84,23 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.36.7",
+ "object 0.37.3",
  "rustc-demangle",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -123,9 +117,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "block-buffer"
@@ -147,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "byteorder"
@@ -159,9 +153,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "bzip2"
@@ -175,12 +169,11 @@ dependencies = [
 
 [[package]]
 name = "bzip2-sys"
-version = "0.1.11+1.0.8"
+version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]
 
@@ -195,10 +188,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.30"
+version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -206,17 +200,16 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
@@ -236,15 +229,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.8"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
+ "once_cell",
  "unicode-width",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -255,27 +248,27 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -292,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -306,7 +299,7 @@ dependencies = [
  "crossterm_winapi",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -323,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -343,21 +336,21 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f1036150ed9aa3265b83b9755a14db1600231e0478e678241e4f4d7c30bcf6"
 dependencies = [
- "thiserror 1.0.64",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "cwextab"
-version = "1.1.2"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd95393b8cc20937e4757d9c22b89d016613e934c60dcb073bd8a5aade79fcf"
+checksum = "e23dadbc8945746c361e3967336075be7281a5455c06f5c5a17fddca4e7d2175"
 dependencies = [
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "decomp-toolkit"
-version = "1.6.2"
+version = "1.8.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -369,7 +362,7 @@ dependencies = [
  "chrono",
  "crossterm",
  "cwdemangle",
- "cwextab 1.1.2",
+ "cwextab 1.1.7",
  "dyn-clone",
  "enable-ansi-support",
  "encoding_rs",
@@ -377,10 +370,11 @@ dependencies = [
  "fixedbitset",
  "flagset",
  "glob",
+ "gnuv2_demangle",
  "hex",
  "indent",
  "indexmap",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "memchr",
  "memmap2",
@@ -404,13 +398,22 @@ dependencies = [
  "serde_yaml",
  "sha-1",
  "size",
- "supports-color 3.0.1",
+ "supports-color 3.0.2",
  "tracing",
  "tracing-attributes",
  "tracing-subscriber",
  "typed-path",
  "xxhash-rust",
  "zerocopy",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -425,15 +428,15 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.17"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "enable-ansi-support"
@@ -446,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "encode_unicode"
-version = "0.3.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -461,18 +464,18 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -489,15 +492,20 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "filetime"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
 dependencies = [
  "cfg-if",
  "libc",
  "libredox",
- "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
@@ -507,18 +515,18 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flagset"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3ea1ec5f8307826a5b71094dd91fc04d4ae75d5709b20ad351c7fb4815c86ec"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "flate2"
-version = "1.0.34"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
+checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -542,45 +550,57 @@ dependencies = [
 
 [[package]]
 name = "getopts"
-version = "0.2.21"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
  "unicode-width",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasip2",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gnuv2_demangle"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4eda49d36ceaaaf3af38940a636b0514472cdba8b2158b20b58e91e50df4c7"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -590,9 +610,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -605,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -635,55 +655,46 @@ checksum = "d9f1a0777d972970f204fdf8ef319f1f4f8459131636d7e3c96c5d59570d0fa6"
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
 name = "indicatif"
-version = "0.17.8"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
 dependencies = [
  "console",
- "instant",
  "number_prefix",
  "portable-atomic",
  "unicode-width",
+ "web-time",
 ]
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "is-terminal"
-version = "0.4.13"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -702,25 +713,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.11"
+name = "itertools"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
+ "getrandom",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -734,24 +755,24 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "liblzma"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c45fc6fcf5b527d3cf89c1dee8c327943984b0dc8bfcf6e100473b00969e63"
+checksum = "a631d2b24be269775ba8f7789a6afa1ac228346a20c9e87dbbbe4975a79fd764"
 dependencies = [
  "liblzma-sys",
 ]
 
 [[package]]
 name = "liblzma-sys"
-version = "0.3.9"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6630cb23edeb2e563cd6c30d4117554c69646871455843c33ddcb1d9aef82ecf"
+checksum = "efdadf1a99aceff34553de1461674ab6ac7e7f0843ae9875e339f4a14eb43475"
 dependencies = [
  "cc",
  "libc",
@@ -760,9 +781,9 @@ dependencies = [
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.39"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
 dependencies = [
  "cc",
  "libc",
@@ -770,13 +791,13 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.7.0",
 ]
 
 [[package]]
@@ -786,28 +807,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
-name = "lock_api"
-version = "0.4.13"
+name = "linux-raw-sys"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -822,54 +848,55 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmap2"
-version = "0.9.5"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "mimalloc"
-version = "0.1.43"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
 dependencies = [
  "libmimalloc-sys",
 ]
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "multimap"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 dependencies = [
  "serde",
 ]
@@ -888,13 +915,13 @@ dependencies = [
  "digest",
  "dyn-clone",
  "encoding_rs",
- "itertools",
+ "itertools 0.13.0",
  "liblzma",
  "log",
  "miniz_oxide",
  "rayon",
  "sha1",
- "thiserror 1.0.64",
+ "thiserror 1.0.69",
  "zerocopy",
  "zstd",
 ]
@@ -912,7 +939,7 @@ dependencies = [
  "enable-ansi-support",
  "hex",
  "indicatif",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "md-5",
  "mimalloc",
@@ -921,7 +948,7 @@ dependencies = [
  "serde",
  "sha1",
  "size",
- "supports-color 3.0.1",
+ "supports-color 3.0.2",
  "tracing",
  "tracing-attributes",
  "tracing-subscriber",
@@ -932,13 +959,18 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
@@ -951,23 +983,33 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
 dependencies = [
  "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1003,72 +1045,67 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "object"
 version = "0.37.1"
 source = "git+https://github.com/rjkiv/object.git#839a1c3d7f29c5f0f2c4414c44bc6ed68afa580d"
 dependencies = [
  "crc32fast",
  "flate2",
- "hashbrown",
+ "hashbrown 0.15.5",
  "indexmap",
  "memchr",
  "ruzstd",
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.20.2"
+name = "object"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "orthrus-core"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad3db74dec173db0794aadee37558a5ca1f944ed0bd0c340bbad7103af0dc06a"
+checksum = "2e2e1a17ba8c66221472d521c88cee3c4b45ce29122b6c5ee3163942e7a5837a"
 dependencies = [
  "snafu",
+ "time",
 ]
 
 [[package]]
 name = "orthrus-ncompress"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2640cb31ca7922ee276a079c0fc593e0a8003967fe4d815e153a585ba05d3c1"
+checksum = "dd849fa8ca4da01f296f00f5f55e278ddbd5abc12971fd3dd6999d52e2d0d56c"
 dependencies = [
  "orthrus-core",
  "snafu",
 ]
 
 [[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
 name = "owo-colors"
-version = "4.1.0"
+version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
+checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 dependencies = [
  "supports-color 2.1.0",
- "supports-color 3.0.1",
+ "supports-color 3.0.2",
 ]
 
 [[package]]
 name = "parking_lot"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1076,15 +1113,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -1094,7 +1131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6eea3058763d6e656105d1403cb04e0a41b7bbac6362d413e7c33be0c32279c9"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.13.0",
  "prost",
  "prost-types",
 ]
@@ -1122,21 +1159,27 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
-version = "1.9.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powerpc"
@@ -1146,34 +1189,34 @@ checksum = "f9cac36a8d92f3c9d38ebfa606e3bbbbec229a8d757f03de0999898522856e33"
 
 [[package]]
 name = "ppc750cl"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8e5b9d48ab30323e8ece6d655d20fc16a570e4f1af0de6890d3e9ebd284ba0"
+checksum = "405ab38d4b7a4168632c9208bcb11914730fdf847f12ff1442423b38693fabfa"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.34"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.2.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1195,7 +1238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -1204,7 +1247,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.101",
+ "syn 2.0.114",
  "tempfile",
 ]
 
@@ -1215,10 +1258,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1254,9 +1297,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -1269,9 +1312,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -1279,9 +1322,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -1289,62 +1332,56 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.8",
- "regex-syntax 0.8.5",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.1.10"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustix"
@@ -1355,30 +1392,43 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.21"
+name = "rustix"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ruzstd"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640bec8aad418d7d03c72ea2de10d5c646a598f9883c7babc160d91e3c1b26c"
+checksum = "e5ff0cc5e135c8870a775d3320910cd9b564ec036b4dc0b8741629020be63f01"
 dependencies = [
  "twox-hash",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "sanitise-file-name"
@@ -1400,10 +1450,11 @@ checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -1419,14 +1470,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.210"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1437,30 +1497,31 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.129"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbcf9b78a125ee667ae19388837dd12294b858d101fdd393cb9d5501ef09eb2"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "serde_repr"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1525,9 +1586,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio",
@@ -1536,12 +1597,19 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "similar"
@@ -1557,29 +1625,29 @@ checksum = "9fed904c7fb2856d868b92464fc8fa597fce366edea1a9cbfaa8cb5fe080bd6d"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "snafu"
-version = "0.8.5"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223891c85e2a29c3fe8fb900c1fae5e69c2e42415e3177752e8718475efa5019"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
 dependencies = [
  "snafu-derive",
 ]
 
 [[package]]
 name = "snafu-derive"
-version = "0.8.5"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1601,7 +1669,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1616,9 +1684,9 @@ dependencies = [
 
 [[package]]
 name = "supports-color"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8775305acf21c96926c900ad056abeef436701108518cf890020387236ac5a77"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
 dependencies = [
  "is_ci",
 ]
@@ -1636,9 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1647,90 +1715,122 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.17.1"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
- "cfg-if",
  "fastrand",
  "getrandom",
  "once_cell",
- "rustix",
- "windows-sys 0.59.0",
+ "rustix 1.1.3",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.64",
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.8"
+name = "time"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
  "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -1739,20 +1839,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1771,14 +1871,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -1808,14 +1908,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "twox-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b907da542cbced5261bd3256de1b3a1bf340a3d37f93425a07362a1d687de56"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typed-path"
@@ -1825,30 +1925,27 @@ checksum = "82205ffd44a9697e34fc145491aa47310f9871540bb7909eaa9365e0a9a46607"
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicase"
-version = "2.7.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -1868,9 +1965,9 @@ dependencies = [
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -1885,45 +1982,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1931,24 +2015,34 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
- "wasm-bindgen-backend",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1975,9 +2069,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -1988,46 +2082,46 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
@@ -2049,20 +2143,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -2173,71 +2267,74 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags",
-]
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.12"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.6"
+version = "0.8.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a65238aacd5fb83fb03fcaf94823e71643e937000ec03c46e7da94234b10c870"
+checksum = "7456cf00f0685ad319c5b1693f291a650eaf345e941d082fc4e03df8a03996ac"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.6"
+version = "0.8.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ca22c4ad176b37bd81a565f66635bde3d654fe6832730c3e52e1018ae1655ee"
+checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.114",
 ]
 
 [[package]]
-name = "zstd"
-version = "0.13.2"
+name = "zmij"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.1"
+version = "7.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
+version = "2.0.16+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "decomp-toolkit"
 description = "Yet another GameCube/Wii decompilation toolkit."
 authors = ["Luke Street <luke@street.dev>"]
 license = "MIT OR Apache-2.0"
-version = "1.6.2"
+version = "1.8.0"
 edition = "2021"
 publish = false
 repository = "https://github.com/encounter/decomp-toolkit"
@@ -44,6 +44,7 @@ filetime = "0.2"
 fixedbitset = "0.5"
 flagset = { version = "0.4", features = ["serde"] }
 glob = "0.3"
+gnuv2_demangle = "0.4"
 hex = "0.4"
 indent = "0.1"
 indexmap = "2.6"
@@ -55,7 +56,7 @@ multimap = "0.10"
 nodtool = "1.4"
 #nodtool = { path = "../nod-rs/nodtool" }
 num_enum = "0.7"
-#objdiff-core = { version = "2.2", features = ["ppc"] }
+#objdiff-core = { version = "=2.2", features = ["ppc"] }
 #objdiff-core = { path = "../objdiff/objdiff-core", features = ["ppc"] }
 objdiff-core = { git = "https://github.com/rjkiv/objdiff.git", branch = "main2.2.0", features = ["ppc"] }
 #object = { version = "0.37.1", features = ["read_core", "write_core", "std", "elf", "write_std"], default-features = false }

--- a/deny.toml
+++ b/deny.toml
@@ -74,13 +74,15 @@ ignore = [
     #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
-    { id = "RUSTSEC-2024-0384", reason = "unmaintained transient dependency, will be updated in next nod version" },
+    { id = "RUSTSEC-2025-0056", reason = "adler crate used via nodtool has no maintained alternative yet" },
+    { id = "RUSTSEC-2025-0048", reason = "tsify-next is unmaintained but required by objdiff-core" },
+    { id = "RUSTSEC-2025-0119", reason = "unmaintained transient dependency (number_prefix)" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.
 # Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
 # See Git Authentication for more information about setting up git authentication.
-#git-fetch-with-cli = true
+git-fetch-with-cli = true
 
 # This section is considered when running `cargo deny check licenses`
 # More documentation for the licenses section can be found here:
@@ -98,7 +100,7 @@ allow = [
     "ISC",
     "MIT",
     "MPL-2.0",
-    "Unicode-DFS-2016",
+    "Unicode-3.0",
     "Zlib",
 ]
 # The confidence threshold for detecting a license from license text.

--- a/src/analysis/cfa.rs
+++ b/src/analysis/cfa.rs
@@ -1,6 +1,6 @@
 use std::{
     cmp::min,
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     fmt::{Debug, Display, Formatter, UpperHex},
     ops::{Add, AddAssign, BitAnd, Sub},
 };
@@ -11,15 +11,15 @@ use itertools::Itertools;
 use crate::{
     analysis::{
         executor::{ExecCbData, ExecCbResult, Executor},
-        skip_alignment,
         slices::{FunctionSlices, TailCallResult},
         vm::{BranchTarget, GprValue, StepResult, VM},
         RelocationTarget,
     },
     obj::{
-        ObjInfo, ObjSectionKind, ObjSymbol, ObjSymbolFlagSet, ObjSymbolFlags, ObjSymbolKind,
-        SectionIndex,
+        ObjInfo, ObjSection, ObjSectionKind, ObjSymbol, ObjSymbolFlagSet, ObjSymbolFlags,
+        ObjSymbolKind, SectionIndex,
     },
+    util::config::create_auto_symbol_name,
 };
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -124,9 +124,21 @@ pub struct AnalyzerState {
     pub jump_tables: BTreeMap<SectionAddress, u32>,
     pub known_symbols: BTreeMap<SectionAddress, Vec<ObjSymbol>>,
     pub known_sections: BTreeMap<SectionIndex, String>,
+    pub skip_ranges: BTreeMap<SectionAddress, SectionAddress>,
 }
 
 impl AnalyzerState {
+    pub fn new(skip_ranges: BTreeMap<SectionAddress, SectionAddress>) -> Self {
+        Self {
+            sda_bases: None,
+            functions: BTreeMap::new(),
+            jump_tables: BTreeMap::new(),
+            known_symbols: BTreeMap::new(),
+            known_sections: BTreeMap::new(),
+            skip_ranges,
+        }
+    }
+
     pub fn apply(&self, obj: &mut ObjInfo) -> Result<()> {
         for (&section_index, section_name) in &self.known_sections {
             obj.sections[section_index].rename(section_name.clone())?;
@@ -143,11 +155,7 @@ impl AnalyzerState {
                 section.address,
                 section.address + section.size
             );
-            let name = if obj.module_id == 0 {
-                format!("fn_{:08X}", start.address)
-            } else {
-                format!("fn_{}_{:X}", obj.module_id, start.address)
-            };
+            let name = create_auto_symbol_name("fn", obj.module_id, start.address);
             obj.add_symbol(
                 ObjSymbol {
                     name,
@@ -404,12 +412,7 @@ impl AnalyzerState {
                 log::trace!("Finalizing {:#010X}", addr);
                 slices.finalize(obj, &self.functions)?;
                 for address in slices.function_references.iter().cloned() {
-                    // Only create functions for code sections
-                    // Some games use branches to data sections to prevent dead stripping (Mario Party)
-                    if matches!(obj.sections.get(address.section), Some(section) if section.kind == ObjSectionKind::Code)
-                    {
-                        self.functions.entry(address).or_default();
-                    }
+                    self.try_add_function(obj, address);
                 }
                 self.jump_tables.append(&mut slices.jump_table_references.clone());
                 let end = slices.end();
@@ -421,6 +424,25 @@ impl AnalyzerState {
             }
         }
         Ok(finalized_any)
+    }
+
+    fn try_add_function(&mut self, obj: &ObjInfo, address: SectionAddress) {
+        // Only create functions for code sections
+        // Some games use branches to data sections to prevent dead stripping (Mario Party)
+        if !matches!(obj.sections.get(address.section), Some(section) if section.kind == ObjSectionKind::Code)
+            // Avoid creating functions in skipped ranges
+            || self.in_skipped_range(address)
+        {
+            return;
+        }
+        self.functions.entry(address).or_default();
+    }
+
+    fn in_skipped_range(&self, address: SectionAddress) -> bool {
+        match self.skip_ranges.range(..=address).next_back() {
+            Some((&start, &end)) => address >= start && address < end,
+            None => false,
+        }
     }
 
     fn first_unbounded_function(&self) -> Option<SectionAddress> {
@@ -447,12 +469,7 @@ impl AnalyzerState {
     pub fn process_function_at(&mut self, obj: &ObjInfo, addr: SectionAddress) -> Result<bool> {
         Ok(if let Some(mut slices) = self.process_function(obj, addr)? {
             for address in slices.function_references.iter().cloned() {
-                // Only create functions for code sections
-                // Some games use branches to data sections to prevent dead stripping (Mario Party)
-                if matches!(obj.sections.get(address.section), Some(section) if section.kind == ObjSectionKind::Code)
-                {
-                    self.functions.entry(address).or_default();
-                }
+                self.try_add_function(obj, address);
             }
             self.jump_tables.append(&mut slices.jump_table_references.clone());
             if slices.can_finalize() {
@@ -506,7 +523,7 @@ impl AnalyzerState {
                         if first_end > second {
                             bail!("Overlapping functions {}-{} -> {}", first, first_end, second);
                         }
-                        let addr = match skip_alignment(section, first_end, second) {
+                        let addr = match self.skip_alignment(section, first_end, second) {
                             Some(addr) => addr,
                             None => continue,
                         };
@@ -533,7 +550,7 @@ impl AnalyzerState {
                     (Some((last, last_info)), None) => {
                         let Some(last_end) = last_info.end else { continue };
                         if last_end < section_end {
-                            let addr = match skip_alignment(section, last_end, section_end) {
+                            let addr = match self.skip_alignment(section, last_end, section_end) {
                                 Some(addr) => addr,
                                 None => continue,
                             };
@@ -559,6 +576,33 @@ impl AnalyzerState {
             ensure!(opt.is_none(), "Attempted to detect duplicate function @ {:#010X}", addr);
         }
         Ok(found_new)
+    }
+
+    fn skip_alignment(
+        &self,
+        section: &ObjSection,
+        mut addr: SectionAddress,
+        end: SectionAddress,
+    ) -> Option<SectionAddress> {
+        loop {
+            if let Some((&start, &end)) = self.skip_ranges.range(..=addr).next_back() {
+                if addr >= start && addr < end {
+                    addr = end;
+                }
+            };
+            if addr.address + 4 > end.address {
+                break None;
+            }
+            let data = match section.data_range(addr.address, addr.address + 4) {
+                Ok(data) => data,
+                Err(_) => return None,
+            };
+            if data == [0u8; 4] {
+                addr += 4;
+            } else {
+                break Some(addr);
+            }
+        }
     }
 }
 
@@ -613,6 +657,26 @@ pub fn locate_sda_bases(obj: &mut ObjInfo) -> Result<bool> {
         Some((sda2_base, sda_base)) => {
             obj.sda2_base = Some(sda2_base as u32);
             obj.sda_base = Some(sda_base as u32);
+            obj.add_symbol(
+                ObjSymbol {
+                    name: "_SDA2_BASE_".to_string(),
+                    address: sda2_base as u64,
+                    size_known: true,
+                    flags: ObjSymbolFlagSet(ObjSymbolFlags::Global.into()),
+                    ..Default::default()
+                },
+                true,
+            )?;
+            obj.add_symbol(
+                ObjSymbol {
+                    name: "_SDA_BASE_".to_string(),
+                    address: sda_base as u64,
+                    size_known: true,
+                    flags: ObjSymbolFlagSet(ObjSymbolFlags::Global.into()),
+                    ..Default::default()
+                },
+                true,
+            )?;
             Ok(true)
         }
         None => Ok(false),
@@ -622,7 +686,7 @@ pub fn locate_sda_bases(obj: &mut ObjInfo) -> Result<bool> {
 /// ProDG hardcodes .bss and .sbss section initialization in `entry`
 /// This function locates the memset calls and returns a list of
 /// (address, size) pairs for the .bss sections.
-pub fn locate_bss_memsets(obj: &mut ObjInfo) -> Result<Vec<(u32, u32)>> {
+pub fn locate_bss_memsets(obj: &ObjInfo) -> Result<Vec<(u32, u32)>> {
     let mut bss_sections: Vec<(u32, u32)> = Vec::new();
     let Some(entry) = obj.entry else {
         return Ok(bss_sections);
@@ -672,4 +736,51 @@ pub fn locate_bss_memsets(obj: &mut ObjInfo) -> Result<Vec<(u32, u32)>> {
         },
     )?;
     Ok(bss_sections)
+}
+
+/// Execute VM from specified entry point following inner-section branches and function calls,
+/// noting all branch targets outside the current section.
+pub fn locate_cross_section_branch_targets(
+    obj: &ObjInfo,
+    entry: SectionAddress,
+) -> Result<BTreeSet<SectionAddress>> {
+    let mut branch_targets = BTreeSet::<SectionAddress>::new();
+    let mut executor = Executor::new(obj);
+    executor.push(entry, VM::new(), false);
+    executor.run(
+        obj,
+        |ExecCbData { executor, vm, result, ins_addr, section: _, ins: _, block_start: _ }| {
+            match result {
+                StepResult::Continue | StepResult::LoadStore { .. } => {
+                    Ok(ExecCbResult::<()>::Continue)
+                }
+                StepResult::Illegal => bail!("Illegal instruction @ {}", ins_addr),
+                StepResult::Jump(target) => {
+                    if let BranchTarget::Address(RelocationTarget::Address(addr)) = target {
+                        if addr.section == entry.section {
+                            executor.push(addr, vm.clone_all(), true);
+                        } else {
+                            branch_targets.insert(addr);
+                        }
+                    }
+                    Ok(ExecCbResult::EndBlock)
+                }
+                StepResult::Branch(branches) => {
+                    for branch in branches {
+                        if let BranchTarget::Address(RelocationTarget::Address(addr)) =
+                            branch.target
+                        {
+                            if addr.section == entry.section {
+                                executor.push(addr, branch.vm, true);
+                            } else {
+                                branch_targets.insert(addr);
+                            }
+                        }
+                    }
+                    Ok(ExecCbResult::Continue)
+                }
+            }
+        },
+    )?;
+    Ok(branch_targets)
 }

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -321,25 +321,3 @@ pub fn uniq_jump_table_entries(
     .with_context(|| format!("While fetching jump table entries starting at {addr:#010X}"))?;
     Ok((BTreeSet::from_iter(entries.iter().cloned()), size))
 }
-
-pub fn skip_alignment(
-    section: &ObjSection,
-    mut addr: SectionAddress,
-    end: SectionAddress,
-) -> Option<SectionAddress> {
-    let mut data = match section.data_range(addr.address, end.address) {
-        Ok(data) => data,
-        Err(_) => return None,
-    };
-    loop {
-        if data.is_empty() {
-            break None;
-        }
-        if data[0..4] == [0u8; 4] {
-            addr += 4;
-            data = &data[4..];
-        } else {
-            break Some(addr);
-        }
-    }
-}

--- a/src/analysis/slices.rs
+++ b/src/analysis/slices.rs
@@ -103,8 +103,8 @@ fn check_prologue_sequence(
     }
     #[inline(always)]
     fn is_stwu(ins: Ins) -> bool {
-        // stwu r1, d(r1)
-        ins.op == Opcode::Stwu && ins.field_rs() == 1 && ins.field_ra() == 1
+        // stwu[x] r1, d(r1)
+        matches!(ins.op, Opcode::Stwu | Opcode::Stwux) && ins.field_rs() == 1 && ins.field_ra() == 1
     }
     #[inline(always)]
     fn is_stw(ins: Ins) -> bool {
@@ -225,7 +225,11 @@ impl FunctionSlices {
             ins.op == Opcode::Or && ins.field_rd() == 1
         }
 
-        if check_sequence(section, addr, Some(ins), &[(&is_mtlr, &is_addi), (&is_or, &is_mtlr)])? {
+        if check_sequence(section, addr, Some(ins), &[
+            (&is_mtlr, &is_addi),
+            (&is_mtlr, &is_or),
+            (&is_or, &is_mtlr),
+        ])? {
             if let Some(epilogue) = self.epilogue {
                 if epilogue != addr {
                     bail!("Found duplicate epilogue: {:#010X} and {:#010X}", epilogue, addr)
@@ -398,23 +402,14 @@ impl FunctionSlices {
                         function_end.or_else(|| self.end()),
                     )?;
                     log::debug!("-> size {}: {:?}", size, entries);
-
-                    // if this function has a known end, check that every jump table entry is within function bounds
-                    let within_func_bounds = match function_end {
-                        Some(end) => {
-                            !entries.iter().any(|&addr| addr < function_start || addr >= end)
-                        }
-                        None => false,
-                    };
-
-                    // this if statements is true if:
-                    // the next_address is in our jump table entries OR next_address marks the start of one our established blocks
-                    // OR we're within known func bounds
-                    // AND
-                    // none of our jump table entries are known function starts
-                    if (entries.contains(&next_address)
-                        || self.blocks.contains_key(&next_address)
-                        || within_func_bounds)
+                    let max_block = self
+                        .blocks
+                        .keys()
+                        .next_back()
+                        .copied()
+                        .unwrap_or(next_address)
+                        .max(next_address);
+                    if entries.iter().any(|&addr| addr > function_start && addr <= max_block)
                         && !entries.iter().any(|&addr| {
                             self.is_known_function(known_functions, addr)
                                 .is_some_and(|fn_addr| fn_addr != function_start)
@@ -800,7 +795,7 @@ impl FunctionSlices {
                 }
             }
             // If we discovered a function prologue, known tail call.
-            if slices.prologue.is_some() {
+            if slices.prologue.is_some() || slices.has_r1_load {
                 log::trace!("Prologue discovered; known tail call: {:#010X}", addr);
                 return TailCallResult::Is;
             }

--- a/src/analysis/tracker.rs
+++ b/src/analysis/tracker.rs
@@ -21,6 +21,7 @@ use crate::{
         ObjDataKind, ObjInfo, ObjKind, ObjReloc, ObjRelocKind, ObjSection, ObjSectionKind,
         ObjSymbol, ObjSymbolFlagSet, ObjSymbolFlags, ObjSymbolKind, SectionIndex, SymbolIndex,
     },
+    util::config::{create_auto_symbol_name, is_auto_symbol},
 };
 
 #[derive(Debug, Copy, Clone)]
@@ -841,6 +842,23 @@ impl Tracker {
                 }
             }
         }
+
+        // Rename all discovered extab dtors from extab relocations
+        if let Some((_, extab_section)) = obj.sections.by_name("extab")? {
+            for (_, reloc) in extab_section.relocations.iter() {
+                let symbol = &obj.symbols[reloc.target_symbol];
+                // Only rename auto symbols
+                if is_auto_symbol(symbol) {
+                    let mut new_symbol = symbol.clone();
+                    let name =
+                        create_auto_symbol_name("dtor", obj.module_id, symbol.address as u32);
+
+                    new_symbol.name = name;
+                    obj.symbols.replace(reloc.target_symbol, new_symbol)?;
+                }
+            }
+        }
+
         Ok(())
     }
 }

--- a/src/cmd/dol.rs
+++ b/src/cmd/dol.rs
@@ -234,6 +234,9 @@ pub struct ProjectConfig {
     /// Marks all emitted symbols as "exported" to prevent the linker from removing them.
     #[serde(default = "bool_true", skip_serializing_if = "is_true")]
     pub export_all: bool,
+    /// Promotes local symbols referenced by other units to global.
+    #[serde(default = "bool_true", skip_serializing_if = "is_true")]
+    pub globalize_symbols: bool,
     /// Optional base path for all object files.
     #[serde(with = "unix_path_serde_option", default, skip_serializing_if = "is_default")]
     pub object_base: Option<Utf8UnixPathBuf>,
@@ -259,6 +262,7 @@ impl Default for ProjectConfig {
             symbols_known: false,
             fill_gaps: true,
             export_all: true,
+            globalize_symbols: true,
             object_base: None,
             extract_objects: true,
         }
@@ -299,6 +303,8 @@ pub struct ModuleConfig {
     /// Process exception tables and zero out uninitialized data.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub clean_extab: Option<bool>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skip_cfa_ranges: Vec<SkipCfaRangeConfig>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -315,6 +321,10 @@ pub struct ExtractConfig {
     /// Path is relative to `out_dir/include`.
     #[serde(with = "unix_path_serde_option", default, skip_serializing_if = "Option::is_none")]
     pub header: Option<Utf8UnixPathBuf>,
+    /// If specified, any relocations within the symbol will be written to the given file in JSON
+    /// format. Path is relative to `out_dir/bin`.
+    #[serde(with = "unix_path_serde_option", default, skip_serializing_if = "Option::is_none")]
+    pub relocations: Option<Utf8UnixPathBuf>,
     /// The type for the extracted symbol in the header file. By default, the header will emit
     /// a full symbol declaration (a.k.a. `symbol`), but this can be set to `raw` to emit the raw
     /// data as a byte array. `none` avoids emitting a header entirely, in which case the `header`
@@ -361,6 +371,16 @@ pub struct AddRelocationConfig {
     pub addend: i64,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct SkipCfaRangeConfig {
+    /// The start address of the range to skip.
+    /// Format: `section:address`, e.g. `.text:0x80001234`.
+    pub start: SectionAddressRef,
+    /// The end address of the range to skip.
+    /// Format: `section:address`, e.g. `.text:0x80001234`.
+    pub end: SectionAddressRef,
+}
+
 impl ModuleConfig {
     pub fn file_name(&self) -> &str { self.object.file_name().unwrap_or(self.object.as_str()) }
 
@@ -370,6 +390,19 @@ impl ModuleConfig {
     }
 
     pub fn name(&self) -> &str { self.name.as_deref().unwrap_or_else(|| self.file_prefix()) }
+
+    pub fn skip_cfa_ranges(
+        &self,
+        obj: &ObjInfo,
+    ) -> Result<BTreeMap<SectionAddress, SectionAddress>> {
+        let mut skip_cfa_ranges = BTreeMap::new();
+        for range in &self.skip_cfa_ranges {
+            let start = range.start.resolve(obj)?;
+            let end = range.end.resolve(obj)?;
+            skip_cfa_ranges.insert(start, end);
+        }
+        Ok(skip_cfa_ranges)
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -401,9 +434,22 @@ pub struct OutputExtract {
     pub binary: Option<Utf8UnixPathBuf>,
     #[serde(with = "unix_path_serde_option")]
     pub header: Option<Utf8UnixPathBuf>,
+    #[serde(with = "unix_path_serde_option")]
+    pub relocations: Option<Utf8UnixPathBuf>,
     pub header_type: String,
     pub custom_type: Option<String>,
     pub custom_data: Option<serde_json::Value>,
+}
+
+#[derive(Serialize)]
+struct ExtractRelocInfo {
+    offset: u32,
+    #[serde(rename = "type")]
+    kind: ObjRelocKind,
+    target: String,
+    addend: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    module: Option<u32>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, Hash)]
@@ -540,7 +586,9 @@ pub fn info(args: InfoArgs) -> Result<()> {
         apply_selfile(&mut obj, file.map()?)?;
     }
 
-    println!("{}:", obj.name);
+    if !obj.name.is_empty() {
+        println!("{}:", obj.name);
+    }
     if let Some(entry) = obj.entry {
         println!("Entry point: {entry:#010X}");
     }
@@ -608,17 +656,17 @@ fn update_symbols(
         .filter(|(_, r)| r.module_id == obj.module_id)
     {
         if source_module_id == obj.module_id {
-            // Skip if already resolved
-            let (_, source_section) =
-                obj.sections.get_elf_index(rel_reloc.section as SectionIndex).ok_or_else(|| {
-                    anyhow!(
-                        "Failed to locate REL section {} in module ID {}: source module {}, {:?}",
-                        rel_reloc.section,
-                        obj.module_id,
-                        source_module_id,
-                        rel_reloc
-                    )
-                })?;
+            let Some((_, source_section)) =
+                obj.sections.get_elf_index(rel_reloc.section as SectionIndex)
+            else {
+                log::warn!(
+                    "Missing relocation module {}, section {}; skipping",
+                    obj.module_id,
+                    rel_reloc.section
+                );
+                continue;
+            };
+
             if source_section.relocations.contains(rel_reloc.address) {
                 continue;
             }
@@ -689,15 +737,16 @@ fn create_relocations(
     // Resolve all relocations in this module
     for rel_reloc in take(&mut obj.unresolved_relocations) {
         // Skip if already resolved
-        let (_, source_section) =
-            obj.sections.get_elf_index(rel_reloc.section as SectionIndex).ok_or_else(|| {
-                anyhow!(
-                    "Failed to locate REL section {} in module ID {}: {:?}",
-                    rel_reloc.section,
-                    obj.module_id,
-                    rel_reloc
-                )
-            })?;
+        let Some((_, source_section)) =
+            obj.sections.get_elf_index(rel_reloc.section as SectionIndex)
+        else {
+            log::warn!(
+                "Missing relocation module {}, section {}; skipping",
+                obj.module_id,
+                rel_reloc.section
+            );
+            continue;
+        };
         if source_section.relocations.contains(rel_reloc.address) {
             continue;
         }
@@ -754,8 +803,16 @@ fn create_relocations(
                 Some(rel_reloc.module_id)
             },
         };
-        let (_, source_section) =
-            obj.sections.get_elf_index_mut(rel_reloc.section as SectionIndex).unwrap();
+        let Some((_, source_section)) =
+            obj.sections.get_elf_index_mut(rel_reloc.section as SectionIndex)
+        else {
+            log::warn!(
+                "Missing relocation module {}, section {}; skipping",
+                obj.module_id,
+                rel_reloc.section
+            );
+            continue;
+        };
         source_section.relocations.insert(rel_reloc.address, reloc)?;
     }
 
@@ -886,7 +943,9 @@ fn load_analyze_dol(config: &ProjectConfig, object_base: &ObjectBase) -> Result<
         apply_signatures(&mut obj)?;
 
         if !config.quick_analysis {
-            let mut state = AnalyzerState::default();
+            let skip_ranges =
+                config.base.skip_cfa_ranges(&obj).context("Resolving skip CFA ranges")?;
+            let mut state = AnalyzerState::new(skip_ranges);
             debug!("Detecting function boundaries");
             FindSaveRestSleds::execute(&mut state, &obj)?;
             state.detect_functions(&obj)?;
@@ -967,7 +1026,7 @@ fn split_write_obj(
 
     debug!("Splitting {} objects", module.obj.link_order.len());
     let module_name = module.config.name().to_string();
-    let split_objs = split_obj(&module.obj, Some(module_name.as_str()))?;
+    let split_objs = split_obj(&module.obj, Some(module_name.as_str()), config.globalize_symbols)?;
 
     debug!("Writing object files");
     DirBuilder::new()
@@ -1059,12 +1118,35 @@ fn split_write_obj(
             }
         }
 
+        if let Some(relocations) = &extract.relocations {
+            let start = symbol.address as u32 - section.address as u32;
+            let end = start + symbol.size as u32;
+            let mut reloc_entries = Vec::new();
+            for (addr, reloc) in section.relocations.range(start..end) {
+                let target_symbol = &module.obj.symbols[reloc.target_symbol];
+                reloc_entries.push(ExtractRelocInfo {
+                    offset: addr - start,
+                    kind: reloc.kind,
+                    target: target_symbol.name.clone(),
+                    addend: reloc.addend,
+                    module: reloc.module,
+                });
+            }
+            let relocations_json = serde_json::to_vec_pretty(&reloc_entries)?;
+            let out_path = base_dir.join("bin").join(relocations.with_encoding());
+            if let Some(parent) = out_path.parent() {
+                DirBuilder::new().recursive(true).create(parent)?;
+            }
+            write_if_changed(&out_path, &relocations_json)?;
+        }
+
         // Copy to output config
         out_config.extract.push(OutputExtract {
             symbol: symbol.name.clone(),
             rename: extract.rename.clone(),
             binary: extract.binary.clone(),
             header: extract.header.clone(),
+            relocations: extract.relocations.clone(),
             header_type: header_kind.to_string(),
             custom_type: extract.custom_type.clone(),
             custom_data: extract.custom_data.clone(),
@@ -1163,7 +1245,9 @@ fn load_analyze_rel(
     if !config.symbols_known {
         debug!("Analyzing module {}", module_obj.module_id);
         if !config.quick_analysis {
-            let mut state = AnalyzerState::default();
+            let skip_ranges =
+                module_config.skip_cfa_ranges(&module_obj).context("Resolving skip CFA ranges")?;
+            let mut state = AnalyzerState::new(skip_ranges);
             FindSaveRestSleds::execute(&mut state, &module_obj)?;
             state.detect_functions(&module_obj)?;
             FindRelCtorsDtors::execute(&mut state, &module_obj)?;

--- a/src/cmd/xex.rs
+++ b/src/cmd/xex.rs
@@ -272,7 +272,7 @@ fn split_write_obj_exe(
 
     debug!("Splitting {} objects", module.obj.link_order.len());
     let module_name = module.config.name().to_string();
-    let split_objs = split_obj(&module.obj, None)?;
+    let split_objs = split_obj(&module.obj, None, false)?;
 
     debug!("Writing object files");
     DirBuilder::new()
@@ -628,7 +628,7 @@ fn disasm(args: DisasmArgs) -> Result<()> {
     // Gamepad Release
     apply_splits_file(&args.out, &mut obj)?;
     update_splits(&mut obj, None, false)?;
-    let split_objs = split_obj(&mut obj, None)?;
+    let split_objs = split_obj(&mut obj, None, false)?;
 
     for coff_obj in &split_objs {
         // skip autogenned splits for now

--- a/src/util/config.rs
+++ b/src/util/config.rs
@@ -176,6 +176,16 @@ pub fn parse_symbol_line(line: &str, obj: &mut ObjInfo) -> Result<Option<ObjSymb
     }
 }
 
+pub fn create_auto_symbol_name(prefix: &str, module_id: u32, address: u32) -> String {
+    let name = if module_id == 0 {
+        format!("{}_{:08X}", prefix, address)
+    } else {
+        format!("{}_{}_{:X}", prefix, module_id, address)
+    };
+
+    name
+}
+
 pub fn is_skip_symbol(symbol: &ObjSymbol) -> bool {
     if symbol.flags.is_no_write() {
         return true;
@@ -194,6 +204,7 @@ pub fn is_auto_symbol(symbol: &ObjSymbol) -> bool {
         || symbol.name.starts_with("jumptable_")
         || symbol.name.starts_with("gap_")
         || symbol.name.starts_with("pad_")
+        || symbol.name.starts_with("dtor_")
 }
 
 pub fn is_auto_label(symbol: &ObjSymbol) -> bool { symbol.name.starts_with("lbl_") }
@@ -641,10 +652,7 @@ pub fn apply_splits<R>(r: &mut R, obj: &mut ObjInfo) -> Result<()>
 where R: BufRead + ?Sized {
     let mut state = SplitState::None;
     for result in r.lines() {
-        let line = match result {
-            Ok(line) => line,
-            Err(e) => return Err(e.into()),
-        };
+        let line = result?;
         let split_line = parse_split_line(&line, &state)?;
         match (&mut state, split_line) {
             (
@@ -745,10 +753,7 @@ pub fn read_splits_sections(path: &Utf8NativePath) -> Result<Option<Vec<SectionD
     let mut sections = Vec::new();
     let mut state = SplitState::None;
     for result in file.lines() {
-        let line = match result {
-            Ok(line) => line,
-            Err(e) => return Err(e.into()),
-        };
+        let line = result?;
         let split_line = parse_split_line(&line, &state)?;
         match (&mut state, split_line) {
             (SplitState::None | SplitState::Unit(_), SplitLine::SectionsStart) => {

--- a/src/util/dwarf.rs
+++ b/src/util/dwarf.rs
@@ -1,12 +1,15 @@
 use std::{
+    cell::RefCell,
     cmp::max,
-    collections::BTreeMap,
+    collections::{btree_map, BTreeMap, BTreeSet},
     fmt::{Display, Formatter, Write},
     io::{BufRead, Cursor, Seek, SeekFrom},
     num::NonZeroU32,
 };
 
 use anyhow::{anyhow, bail, ensure, Context, Result};
+use cwdemangle::demangle as cw_demangle;
+use gnuv2_demangle::{demangle as gnu_demangle, DemangleConfig};
 use indent::indent_all_by;
 use num_enum::{IntoPrimitive, TryFromPrimitive, TryFromPrimitiveError};
 
@@ -364,11 +367,21 @@ pub struct Tag {
 
 pub type TagMap = BTreeMap<u32, Tag>;
 pub type TypedefMap = BTreeMap<u32, Vec<u32>>;
+pub type MemberFunctionMap = BTreeMap<u32, BTreeSet<u32>>;
 
 #[derive(Debug, Clone)]
 pub struct DwarfInfo {
     pub e: Endian,
     pub tags: TagMap,
+    pub producer: Producer,
+    pub member_functions: RefCell<MemberFunctionMap>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Producer {
+    MWCC,
+    GCC,
+    OTHER,
 }
 
 impl Tag {
@@ -488,7 +501,12 @@ where R: BufRead + Seek + ?Sized {
         len
     };
 
-    let mut info = DwarfInfo { e, tags: BTreeMap::new() };
+    let mut info = DwarfInfo {
+        e,
+        tags: BTreeMap::new(),
+        producer: Producer::OTHER,
+        member_functions: RefCell::new(MemberFunctionMap::new()),
+    };
     loop {
         let position = reader.stream_position()?;
         if position >= len {
@@ -500,6 +518,14 @@ where R: BufRead + Seek + ?Sized {
         }
     }
     Ok(info)
+}
+
+pub fn parse_producer(producer: &str) -> Producer {
+    match producer {
+        p if p.starts_with("MW") => Producer::MWCC,
+        p if p.starts_with("GNU C") => Producer::GCC,
+        _ => Producer::OTHER,
+    }
 }
 
 #[allow(unused)]
@@ -738,8 +764,12 @@ pub struct StructureType {
     pub kind: StructureKind,
     pub name: Option<String>,
     pub byte_size: Option<u32>,
+    pub member_functions: Vec<MemberSubroutineDefType>,
     pub members: Vec<StructureMember>,
+    pub static_members: Vec<VariableTag>,
     pub bases: Vec<StructureBase>,
+    pub inner_types: Vec<UserDefinedType>,
+    pub typedefs: Vec<TypedefTag>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -805,8 +835,36 @@ pub struct SubroutineBlock {
     pub start_address: Option<u32>,
     pub end_address: Option<u32>,
     pub variables: Vec<SubroutineVariable>,
-    pub blocks: Vec<SubroutineBlock>,
-    pub inlines: Vec<SubroutineType>,
+    pub blocks_and_inlines: Vec<SubroutineNode>,
+    pub inner_types: Vec<UserDefinedType>,
+    pub typedefs: Vec<TypedefTag>,
+}
+
+#[derive(Debug, Clone)]
+pub enum SubroutineNode {
+    Block(SubroutineBlock),
+    Inline(SubroutineType),
+}
+
+#[derive(Debug, Clone)]
+pub struct MemberSubroutineDefType {
+    pub name: Option<String>,
+    pub mangled_name: Option<String>,
+    pub return_type: Type,
+    pub parameters: Vec<SubroutineParameter>,
+    pub var_args: bool,
+    pub prototyped: bool,
+    pub member_of: Option<u32>,
+    pub direct_member_of: Option<u32>,
+    pub inline: bool,
+    pub virtual_: bool,
+    pub local: bool,
+    pub start_address: Option<u32>,
+    pub end_address: Option<u32>,
+    pub const_: bool,
+    pub static_member: bool,
+    pub override_: bool,
+    pub volatile_: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -819,15 +877,21 @@ pub struct SubroutineType {
     pub prototyped: bool,
     pub references: Vec<u32>,
     pub member_of: Option<u32>,
+    pub direct_member_of: Option<u32>,
     pub variables: Vec<SubroutineVariable>,
     pub inline: bool,
     pub virtual_: bool,
     pub local: bool,
     pub labels: Vec<SubroutineLabel>,
-    pub blocks: Vec<SubroutineBlock>,
-    pub inlines: Vec<SubroutineType>,
+    pub blocks_and_inlines: Vec<SubroutineNode>,
+    pub inner_types: Vec<UserDefinedType>,
+    pub typedefs: Vec<TypedefTag>,
     pub start_address: Option<u32>,
     pub end_address: Option<u32>,
+    pub const_: bool,
+    pub static_member: bool,
+    pub override_: bool,
+    pub volatile_: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -865,7 +929,7 @@ pub struct TypedefTag {
 pub enum TagType {
     Variable(VariableTag),
     Typedef(TypedefTag),
-    UserDefined(UserDefinedType),
+    UserDefined(Box<UserDefinedType>),
 }
 
 #[derive(Debug, Eq, PartialEq, Copy, Clone, IntoPrimitive, TryFromPrimitive)]
@@ -997,14 +1061,7 @@ impl Type {
         }
         match self.kind {
             TypeKind::Fundamental(ft) => ft.size(),
-            TypeKind::UserDefined(key) => {
-                let tag = info
-                    .tags
-                    .get(&key)
-                    .ok_or_else(|| anyhow!("Failed to locate user defined type {}", key))?;
-                let ud_type = ud_type(info, tag)?;
-                ud_type.size(info)
-            }
+            TypeKind::UserDefined(key) => get_udt_by_key(info, key)?.size(info),
         }
     }
 }
@@ -1095,11 +1152,13 @@ pub fn type_string(
                     .ok_or_else(|| anyhow!("typedef without name"))?;
                 TypeString { prefix: td_name.clone(), ..Default::default() }
             } else {
-                let tag = info
-                    .tags
-                    .get(&key)
-                    .ok_or_else(|| anyhow!("Failed to locate user defined type {}", key))?;
-                ud_type_string(info, typedefs, &ud_type(info, tag)?, true, include_anonymous_def)?
+                ud_type_string(
+                    info,
+                    typedefs,
+                    &get_udt_by_key(info, key)?,
+                    true,
+                    include_anonymous_def,
+                )?
             }
         }
     };
@@ -1118,12 +1177,9 @@ fn type_name(info: &DwarfInfo, typedefs: &TypedefMap, t: &Type) -> Result<String
                     .ok_or_else(|| anyhow!("typedef without name"))?
                     .clone()
             } else {
-                let tag = info
-                    .tags
-                    .get(&key)
-                    .ok_or_else(|| anyhow!("Failed to locate user defined type {}", key))?;
-                let udt = ud_type(info, tag)?;
-                udt.name().ok_or_else(|| anyhow!("User defined type without name"))?
+                get_udt_by_key(info, key)?
+                    .name()
+                    .ok_or_else(|| anyhow!("User defined type without name"))?
             }
         }
     })
@@ -1162,7 +1218,7 @@ fn structure_type_string(
 ) -> Result<TypeString> {
     let prefix = if let Some(name) = t.name.as_ref() {
         if name.starts_with('@') {
-            struct_def_string(info, typedefs, t)?
+            structure_def_string(info, typedefs, t)?
         } else if include_keyword {
             match t.kind {
                 StructureKind::Struct => format!("struct {name}"),
@@ -1172,7 +1228,7 @@ fn structure_type_string(
             name.clone()
         }
     } else if include_anonymous_def {
-        struct_def_string(info, typedefs, t)?
+        structure_def_string(info, typedefs, t)?
     } else if include_keyword {
         match t.kind {
             StructureKind::Struct => "struct [anonymous]".to_string(),
@@ -1291,7 +1347,7 @@ pub fn ud_type_def(
             Ok(format!("// Array: {}{}", ts.prefix, ts.suffix))
         }
         UserDefinedType::Subroutine(t) => Ok(subroutine_def_string(info, typedefs, t, is_erased)?),
-        UserDefinedType::Structure(t) => Ok(struct_def_string(info, typedefs, t)?),
+        UserDefinedType::Structure(t) => Ok(structure_def_string(info, typedefs, t)?),
         UserDefinedType::Enumeration(t) => Ok(enum_def_string(t)?),
         UserDefinedType::Union(t) => Ok(union_def_string(info, typedefs, t)?),
         UserDefinedType::PtrToMember(t) => {
@@ -1347,6 +1403,166 @@ pub fn subroutine_type_string(
     Ok(out)
 }
 
+fn member_subroutine_def_string(
+    info: &DwarfInfo,
+    typedefs: &TypedefMap,
+    t: &MemberSubroutineDefType,
+) -> Result<String> {
+    let mut out = String::new();
+
+    let mut base_name_opt = None;
+    let mut direct_base_name_opt = None;
+
+    if let Some(member_of) = t.member_of {
+        let tag = info
+            .tags
+            .get(&member_of)
+            .ok_or_else(|| anyhow!("Failed to locate member_of tag {}", member_of))?;
+        let base_name = tag
+            .string_attribute(AttributeKind::Name)
+            .ok_or_else(|| anyhow!("member_of tag {} has no name attribute", member_of))?;
+
+        if t.override_ {
+            writeln!(out, "// Overrides: {}", base_name)?;
+        }
+        base_name_opt = Some(base_name);
+    }
+
+    if let Some(direct_member_of) = t.direct_member_of {
+        let tag = info
+            .tags
+            .get(&direct_member_of)
+            .ok_or_else(|| anyhow!("Failed to locate direct_member_of tag {}", direct_member_of))?;
+        let direct_base_name = tag.string_attribute(AttributeKind::Name).ok_or_else(|| {
+            anyhow!("direct_member_of tag {} has no name attribute", direct_member_of)
+        })?;
+
+        direct_base_name_opt = Some(direct_base_name);
+        if base_name_opt.is_none() {
+            // Fall back to the parsed out direct_base_name on PS2 MW because it doesn't emit a base class
+            base_name_opt = direct_base_name_opt;
+        }
+    }
+
+    let is_non_static_member = t.direct_member_of.is_some() && !t.static_member;
+
+    if t.local || t.static_member {
+        out.push_str("static ");
+    }
+    if t.inline {
+        out.push_str("inline ");
+    }
+    if t.virtual_ && !t.override_ {
+        out.push_str("virtual ");
+    }
+
+    let mut name_written = false;
+
+    let mut omit_return_type = false;
+    let mut is_gcc_destructor = false;
+    let mut full_written_name = String::new();
+
+    if t.override_ {
+        if let Producer::GCC = info.producer {
+            if let Some(direct_base_name) = direct_base_name_opt {
+                if let Some(name) = t.name.as_ref() {
+                    // in GCC the ctor and dtor are called the same, so we need to check the return value
+                    // this is only for the dtor, the ctor can be left as is
+                    if name == direct_base_name {
+                        if let TypeKind::Fundamental(FundType::Void) = t.return_type.kind {
+                            write!(full_written_name, "~{direct_base_name}")?;
+                            is_gcc_destructor = true;
+                            name_written = true;
+                        }
+                        omit_return_type = true;
+                    }
+                }
+            }
+        }
+    } else if let Some(base_name) = base_name_opt {
+        // Handle constructors and destructors
+        if let Some(name) = t.name.as_ref() {
+            if name == "__dt" {
+                write!(full_written_name, "~{base_name}")?;
+                name_written = true;
+                omit_return_type = true;
+            } else if name == "__ct" {
+                write!(full_written_name, "{base_name}")?;
+                name_written = true;
+                omit_return_type = true;
+            } else if name == base_name {
+                if let TypeKind::Fundamental(FundType::Void) = t.return_type.kind {
+                    write!(full_written_name, "~{base_name}")?;
+                    if let Producer::GCC = info.producer {
+                        is_gcc_destructor = true;
+                    }
+                    name_written = true;
+                }
+                omit_return_type = true;
+            }
+        }
+    }
+    if !name_written {
+        if let Some(name) = t.name.as_ref() {
+            full_written_name.push_str(&maybe_demangle_function_name(info, name));
+        }
+    }
+    let rt = type_string(info, typedefs, &t.return_type, true)?;
+    if !omit_return_type {
+        out.push_str(&rt.prefix);
+        out.push(' ');
+    }
+
+    out.push_str(&full_written_name);
+
+    let mut parameters = String::new();
+    if t.parameters.is_empty() {
+        if t.var_args {
+            parameters = "...".to_string();
+        } else if t.prototyped {
+            parameters = "void".to_string();
+        }
+    } else {
+        let mut start_index = if is_non_static_member { 1 } else { 0 };
+        // omit __in_chrg parameter
+        if is_gcc_destructor {
+            start_index += 1;
+        }
+        for (idx, parameter) in t.parameters.iter().enumerate().skip(start_index) {
+            if idx > start_index {
+                write!(parameters, ", ")?;
+            }
+            let ts = type_string(info, typedefs, &parameter.kind, true)?;
+            if let Some(name) = &parameter.name {
+                write!(parameters, "{} {}{}", ts.prefix, name, ts.suffix)?;
+            } else {
+                write!(parameters, "{}{}", ts.prefix, ts.suffix)?;
+            }
+        }
+        if t.var_args {
+            write!(parameters, ", ...")?;
+        }
+    }
+    write!(out, "({}){}", parameters, rt.suffix)?;
+    if t.const_ {
+        write!(out, " const")?;
+    }
+    if t.volatile_ {
+        write!(out, " volatile")?;
+    }
+    if t.override_ {
+        write!(out, " override")?;
+    }
+
+    if t.inline {
+        write!(out, " {{}}")?;
+    } else {
+        write!(out, ";")?;
+    }
+
+    Ok(out)
+}
+
 pub fn subroutine_def_string(
     info: &DwarfInfo,
     typedefs: &TypedefMap,
@@ -1359,20 +1575,10 @@ pub fn subroutine_def_string(
     } else if let (Some(start), Some(end)) = (t.start_address, t.end_address) {
         writeln!(out, "// Range: {start:#X} -> {end:#X}")?;
     }
-    let rt = type_string(info, typedefs, &t.return_type, true)?;
-    if t.local {
-        out.push_str("static ");
-    }
-    if t.inline {
-        out.push_str("inline ");
-    }
-    if t.virtual_ {
-        out.push_str("virtual ");
-    }
-    out.push_str(&rt.prefix);
-    out.push(' ');
 
-    let mut name_written = false;
+    let mut base_name_opt = None;
+    let mut direct_base_name_opt = None;
+
     if let Some(member_of) = t.member_of {
         let tag = info
             .tags
@@ -1381,24 +1587,112 @@ pub fn subroutine_def_string(
         let base_name = tag
             .string_attribute(AttributeKind::Name)
             .ok_or_else(|| anyhow!("member_of tag {} has no name attribute", member_of))?;
-        write!(out, "{base_name}::")?;
+
+        if t.override_ {
+            writeln!(out, "// Overrides: {}", base_name)?;
+        }
+        base_name_opt = Some(base_name);
+    }
+
+    if let Some(direct_member_of) = t.direct_member_of {
+        let tag = info
+            .tags
+            .get(&direct_member_of)
+            .ok_or_else(|| anyhow!("Failed to locate direct_member_of tag {}", direct_member_of))?;
+        let direct_base_name = tag.string_attribute(AttributeKind::Name).ok_or_else(|| {
+            anyhow!("direct_member_of tag {} has no name attribute", direct_member_of)
+        })?;
+
+        direct_base_name_opt = Some(direct_base_name);
+        if base_name_opt.is_none() {
+            // Fall back to the parsed out direct_base_name on PS2 MW because it doesn't emit a base class
+            base_name_opt = direct_base_name_opt;
+        }
+    }
+
+    let is_non_static_member = t.direct_member_of.is_some() && !t.static_member;
+    if is_non_static_member {
+        if let Some(param) = t.parameters.first() {
+            if let Some(location) = &param.location {
+                writeln!(out, "// this: {}", location)?;
+            }
+        }
+    }
+
+    if t.local || t.static_member {
+        out.push_str("static ");
+    }
+    if t.inline {
+        out.push_str("inline ");
+    }
+    if t.virtual_ && !t.override_ {
+        out.push_str("virtual ");
+    }
+
+    let mut name_written = false;
+
+    let mut omit_return_type = false;
+    let mut is_gcc_destructor = false;
+    let mut full_written_name = String::new();
+
+    if t.override_ {
+        if let Producer::GCC = info.producer {
+            if let Some(direct_base_name) = direct_base_name_opt {
+                // we need to emit the real parent on GCC
+                write!(full_written_name, "{direct_base_name}::")?;
+
+                if let Some(name) = t.name.as_ref() {
+                    // in GCC the ctor and dtor are called the same, so we need to check the return value
+                    // this is only for the dtor, the ctor can be left as is
+                    if name == direct_base_name {
+                        if let TypeKind::Fundamental(FundType::Void) = t.return_type.kind {
+                            write!(full_written_name, "~{direct_base_name}")?;
+                            is_gcc_destructor = true;
+                            name_written = true;
+                        }
+                        omit_return_type = true;
+                    }
+                }
+            }
+        }
+    } else if let Some(base_name) = base_name_opt {
+        write!(full_written_name, "{base_name}::")?;
 
         // Handle constructors and destructors
         if let Some(name) = t.name.as_ref() {
             if name == "__dt" {
-                write!(out, "~{base_name}")?;
+                write!(full_written_name, "~{base_name}")?;
                 name_written = true;
+                omit_return_type = true;
             } else if name == "__ct" {
-                write!(out, "{base_name}")?;
+                write!(full_written_name, "{base_name}")?;
                 name_written = true;
+                omit_return_type = true;
+            } else if name == base_name {
+                if let TypeKind::Fundamental(FundType::Void) = t.return_type.kind {
+                    write!(full_written_name, "~{base_name}")?;
+                    if let Producer::GCC = info.producer {
+                        is_gcc_destructor = true;
+                    }
+                    name_written = true;
+                }
+                omit_return_type = true;
             }
         }
     }
     if !name_written {
         if let Some(name) = t.name.as_ref() {
-            out.push_str(name);
+            full_written_name.push_str(&maybe_demangle_function_name(info, name));
         }
     }
+    let rt = type_string(info, typedefs, &t.return_type, true)?;
+    if !omit_return_type {
+        out.push_str(&rt.prefix);
+        out.push(' ');
+    }
+
+    out.push_str(&full_written_name);
+
     let mut parameters = String::new();
     if t.parameters.is_empty() {
         if t.var_args {
@@ -1407,8 +1701,13 @@ pub fn subroutine_def_string(
             parameters = "void".to_string();
         }
     } else {
-        for (idx, parameter) in t.parameters.iter().enumerate() {
-            if idx > 0 {
+        let mut start_index = if is_non_static_member { 1 } else { 0 };
+        // omit __in_chrg parameter
+        if is_gcc_destructor {
+            start_index += 1;
+        }
+        for (idx, parameter) in t.parameters.iter().enumerate().skip(start_index) {
+            if idx > start_index {
                 write!(parameters, ", ")?;
             }
             let ts = type_string(info, typedefs, &parameter.kind, true)?;
@@ -1425,7 +1724,36 @@ pub fn subroutine_def_string(
             write!(parameters, ", ...")?;
         }
     }
-    write!(out, "({}){} {{", parameters, rt.suffix)?;
+    write!(out, "({}){} ", parameters, rt.suffix)?;
+    if t.const_ {
+        write!(out, "const ")?;
+    }
+    if t.volatile_ {
+        write!(out, "volatile ")?;
+    }
+    if t.override_ {
+        write!(out, "override ")?;
+    }
+    write!(out, "{{")?;
+
+    if !t.inner_types.is_empty() {
+        writeln!(out, "\n    // Inner declarations")?;
+
+        for inner_type in &t.inner_types {
+            writeln!(
+                out,
+                "{};",
+                &indent_all_by(4, &ud_type_def(info, typedefs, inner_type, false)?)
+            )?;
+        }
+    }
+
+    if !t.typedefs.is_empty() {
+        writeln!(out, "\n    // Typedefs")?;
+        for typedef in &t.typedefs {
+            writeln!(out, "{}", &indent_all_by(4, &typedef_string(info, typedefs, typedef)?))?;
+        }
+    }
 
     if !t.variables.is_empty() {
         writeln!(out, "\n    // Local variables")?;
@@ -1470,19 +1798,16 @@ pub fn subroutine_def_string(
         }
     }
 
-    if !t.blocks.is_empty() {
-        writeln!(out, "\n    // Blocks")?;
-        for block in &t.blocks {
-            let block_str = subroutine_block_string(info, typedefs, block)?;
-            out.push_str(&indent_all_by(4, block_str));
-        }
-    }
-
-    if !t.inlines.is_empty() {
-        writeln!(out, "\n    // Inlines")?;
-        for inline in &t.inlines {
-            let inline_str = subroutine_def_string(info, typedefs, inline, is_erased)?;
-            out.push_str(&indent_all_by(4, inline_str));
+    if !t.blocks_and_inlines.is_empty() {
+        for node in &t.blocks_and_inlines {
+            let node_str = match node {
+                SubroutineNode::Block(block) => subroutine_block_string(info, typedefs, block)?,
+                SubroutineNode::Inline(inline) => {
+                    subroutine_def_string(info, typedefs, inline, is_erased)?
+                }
+            };
+            writeln!(out)?;
+            out.push_str(&indent_all_by(4, node_str));
         }
     }
 
@@ -1521,16 +1846,37 @@ fn subroutine_block_string(
         writeln!(var_out)?;
     }
     write!(out, "{}", indent_all_by(4, var_out))?;
-    if !block.inlines.is_empty() {
-        writeln!(out, "\n    // Inlines")?;
-        for inline in &block.inlines {
-            let inline_str = subroutine_def_string(info, typedefs, inline, false)?;
-            out.push_str(&indent_all_by(4, inline_str));
+
+    if !block.inner_types.is_empty() {
+        writeln!(out, "\n    // Inner declarations")?;
+
+        for inner_type in &block.inner_types {
+            writeln!(
+                out,
+                "{};",
+                &indent_all_by(4, &ud_type_def(info, typedefs, inner_type, false)?)
+            )?;
         }
     }
-    for block in &block.blocks {
-        let block_str = subroutine_block_string(info, typedefs, block)?;
-        out.push_str(&indent_all_by(4, block_str));
+
+    if !block.typedefs.is_empty() {
+        writeln!(out, "\n    // Typedefs")?;
+        for typedef in &block.typedefs {
+            writeln!(out, "{}", &indent_all_by(4, &typedef_string(info, typedefs, typedef)?))?;
+        }
+    }
+
+    if !block.blocks_and_inlines.is_empty() {
+        for node in &block.blocks_and_inlines {
+            let node_str = match node {
+                SubroutineNode::Block(block) => subroutine_block_string(info, typedefs, block)?,
+                SubroutineNode::Inline(inline) => {
+                    writeln!(out)?;
+                    subroutine_def_string(info, typedefs, inline, false)?
+                }
+            };
+            out.push_str(&indent_all_by(4, node_str));
+        }
     }
     writeln!(out, "}}")?;
     Ok(out)
@@ -1644,14 +1990,18 @@ fn get_anon_union_groups(members: &[StructureMember], unions: &[AnonUnion]) -> V
     groups
 }
 
-pub fn struct_def_string(
+pub fn structure_def_string(
     info: &DwarfInfo,
     typedefs: &TypedefMap,
     t: &StructureType,
 ) -> Result<String> {
-    let mut out = match t.kind {
-        StructureKind::Struct => "struct".to_string(),
-        StructureKind::Class => "class".to_string(),
+    let mut out = String::new();
+    if let Some(byte_size) = t.byte_size {
+        writeln!(out, "// total size: {byte_size:#X}")?;
+    }
+    match t.kind {
+        StructureKind::Struct => out.push_str("struct"),
+        StructureKind::Class => out.push_str("class"),
     };
     if let Some(name) = t.name.as_ref() {
         if name.starts_with('@') {
@@ -1683,10 +2033,50 @@ pub fn struct_def_string(
             out.push_str(&type_name(info, typedefs, &base.base_type)?);
         }
     }
-    out.push_str(" {\n");
-    if let Some(byte_size) = t.byte_size {
-        writeln!(out, "    // total size: {byte_size:#X}")?;
+    out.push_str(" {");
+    if !t.inner_types.is_empty() {
+        writeln!(out, "\n    // Inner declarations")?;
+        for inner_type in &t.inner_types {
+            writeln!(
+                out,
+                "{};",
+                &indent_all_by(4, &ud_type_def(info, typedefs, inner_type, false)?)
+            )?;
+        }
     }
+
+    if !t.typedefs.is_empty() {
+        writeln!(out, "\n    // Typedefs")?;
+        for typedef in &t.typedefs {
+            writeln!(out, "{}", &indent_all_by(4, &typedef_string(info, typedefs, typedef)?))?;
+        }
+    }
+
+    if !t.member_functions.is_empty() {
+        writeln!(out, "\n    // Functions")?;
+
+        let len = t.member_functions.len();
+        for (i, member_function) in t.member_functions.iter().enumerate() {
+            writeln!(
+                out,
+                "{}",
+                indent_all_by(4, member_subroutine_def_string(info, typedefs, member_function)?)
+            )?;
+
+            if i + 1 < len {
+                writeln!(out)?;
+            }
+        }
+    }
+
+    if !t.static_members.is_empty() {
+        writeln!(out, "\n    // Static members")?;
+        for static_member in &t.static_members {
+            let line = format!("static {}", variable_string(info, typedefs, static_member, true)?);
+            writeln!(out, "{}", indent_all_by(4, &line))?;
+        }
+    }
+
     let mut vis = match t.kind {
         StructureKind::Struct => Visibility::Public,
         StructureKind::Class => Visibility::Private,
@@ -1696,6 +2086,9 @@ pub fn struct_def_string(
     let groups = get_anon_union_groups(&t.members, &unions);
     let mut in_union = 0;
     let mut in_group = 0;
+    if !t.members.is_empty() {
+        writeln!(out, "\n    // Members")?;
+    }
     for (i, member) in t.members.iter().enumerate() {
         if vis != member.visibility {
             vis = member.visibility;
@@ -1997,29 +2390,65 @@ fn process_structure_tag(info: &DwarfInfo, tag: &Tag) -> Result<StructureType> {
         }
     }
 
+    let mut member_functions = Vec::new();
+    if let Some(member_function_set) = info.member_functions.borrow().get(&tag.key) {
+        for function in member_function_set {
+            let function_tag = match info.tags.get(function) {
+                Some(t) => t,
+                None => return Err(anyhow!("Failed to locate function tag {}", function)),
+            };
+            member_functions.push(process_member_subroutine_def_tag(info, function_tag)?);
+        }
+    }
+
     let mut members = Vec::new();
+    let mut static_members = Vec::new();
     let mut bases = Vec::new();
+    let mut inner_types = Vec::new();
+    let mut typedefs = Vec::new();
     for child in tag.children(&info.tags) {
         match child.kind {
             TagKind::Inheritance => bases.push(process_inheritance_tag(info, child)?),
             TagKind::Member => members.push(process_structure_member_tag(info, child)?),
             TagKind::Typedef => {
-                // TODO?
-                // info!("Structure {:?} Typedef: {:?}", name, child);
+                match info.producer {
+                    Producer::MWCC => {
+                        // TODO handle visibility
+                        // MWCC handles static members as typedefs for whatever reason
+                        static_members.push(process_variable_tag(info, child)?)
+                    }
+                    Producer::GCC => {
+                        // GCC generates a typedef in templated structs with the name of the template
+                        // Let's filter it out to not confuse the user
+                        let td = process_typedef_tag(info, child)?;
+                        let is_template = name
+                            .as_deref()
+                            .is_some_and(|n| n.starts_with(&format!("{}<", td.name)));
+                        if !is_template {
+                            typedefs.push(td);
+                        }
+                    }
+                    _ => {
+                        typedefs.push(process_typedef_tag(info, child)?);
+                    }
+                }
             }
             TagKind::Subroutine | TagKind::GlobalSubroutine => {
                 // TODO
             }
             TagKind::GlobalVariable => {
-                // TODO
+                // TODO handle visibility
+                static_members.push(process_variable_tag(info, child)?)
             }
-            TagKind::StructureType
-            | TagKind::ArrayType
-            | TagKind::EnumerationType
-            | TagKind::UnionType
-            | TagKind::ClassType
-            | TagKind::SubroutineType
-            | TagKind::PtrToMemberType => {
+            TagKind::StructureType | TagKind::ClassType => {
+                inner_types.push(UserDefinedType::Structure(process_structure_tag(info, child)?))
+            }
+            TagKind::EnumerationType => inner_types
+                .push(UserDefinedType::Enumeration(process_enumeration_tag(info, child)?)),
+            TagKind::UnionType => {
+                inner_types.push(UserDefinedType::Union(process_union_tag(info, child)?))
+            }
+            TagKind::ArrayType | TagKind::SubroutineType | TagKind::PtrToMemberType => {
                 // Variable type, ignore
             }
             kind => bail!("Unhandled StructureType child {:?}", kind),
@@ -2034,8 +2463,12 @@ fn process_structure_tag(info: &DwarfInfo, tag: &Tag) -> Result<StructureType> {
         },
         name,
         byte_size,
+        member_functions,
         members,
+        static_members,
         bases,
+        inner_types,
+        typedefs,
     })
 }
 
@@ -2142,9 +2575,16 @@ fn process_enumeration_tag(info: &DwarfInfo, tag: &Tag) -> Result<EnumerationTyp
             (AttributeKind::ElementList, AttributeValue::Block(data)) => {
                 let mut cursor = Cursor::new(data);
                 while cursor.position() < data.len() as u64 {
-                    let value = i32::from_reader(&mut cursor, info.e)?;
+                    let value = match byte_size {
+                        Some(1) => Some(i8::from_reader(&mut cursor, info.e)? as i32),
+                        Some(2) => Some(i16::from_reader(&mut cursor, info.e)? as i32),
+                        Some(4) => Some(i32::from_reader(&mut cursor, info.e)?),
+                        _ => None,
+                    };
                     let name = read_string(&mut cursor)?;
-                    members.push(EnumerationMember { name, value });
+                    if let Some(value) = value {
+                        members.push(EnumerationMember { name, value });
+                    }
                 }
             }
             (AttributeKind::Member, &AttributeValue::Reference(_key)) => {
@@ -2162,6 +2602,12 @@ fn process_enumeration_tag(info: &DwarfInfo, tag: &Tag) -> Result<EnumerationTyp
 
     let byte_size =
         byte_size.ok_or_else(|| anyhow!("EnumerationType without ByteSize: {:?}", tag))?;
+
+    if info.producer == Producer::GCC {
+        // for some reason enum members are reversed in GCC
+        members.reverse();
+    }
+
     Ok(EnumerationType { name, byte_size, members })
 }
 
@@ -2206,6 +2652,257 @@ fn process_union_tag(info: &DwarfInfo, tag: &Tag) -> Result<UnionType> {
     Ok(UnionType { name, byte_size, members })
 }
 
+// for member functions
+fn preprocess_subroutine_tag(info: &DwarfInfo, tag: &Tag) -> Result<()> {
+    ensure!(
+        matches!(
+            tag.kind,
+            TagKind::SubroutineType
+                | TagKind::GlobalSubroutine
+                | TagKind::Subroutine
+                | TagKind::InlinedSubroutine
+        ),
+        "{:?} is not a Subroutine tag",
+        tag.kind
+    );
+
+    let mut append_to = None;
+    for child in tag.children(&info.tags) {
+        if child.kind == TagKind::FormalParameter {
+            let param = process_subroutine_parameter_tag(info, child)?;
+            if param.name.as_deref() == Some("this") {
+                if let TypeKind::UserDefined(key) = param.kind.kind {
+                    append_to = Some(key);
+                    break;
+                }
+            }
+        }
+    }
+    // On GCC we can detect static methods because there namespaces aren't retained
+    if info.producer == Producer::GCC && append_to.is_none() {
+        for attr in &tag.attributes {
+            if let (AttributeKind::Member, &AttributeValue::Reference(key)) =
+                (attr.kind, &attr.value)
+            {
+                append_to = Some(key);
+                break;
+            }
+        }
+    }
+
+    if let Some(key) = append_to {
+        match info.member_functions.borrow_mut().entry(key) {
+            btree_map::Entry::Vacant(e) => {
+                let mut set = BTreeSet::new();
+                set.insert(tag.key);
+                e.insert(set);
+            }
+            btree_map::Entry::Occupied(e) => {
+                e.into_mut().insert(tag.key);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn process_member_subroutine_def_tag(
+    info: &DwarfInfo,
+    tag: &Tag,
+) -> Result<MemberSubroutineDefType> {
+    ensure!(
+        matches!(
+            tag.kind,
+            TagKind::SubroutineType
+                | TagKind::GlobalSubroutine
+                | TagKind::Subroutine
+                | TagKind::InlinedSubroutine
+        ),
+        "{:?} is not a Subroutine tag",
+        tag.kind
+    );
+
+    let mut name = None;
+    let mut mangled_name = None;
+    let mut return_type = None;
+    let mut prototyped = false;
+    let mut parameters = Vec::new();
+    let mut var_args = false;
+    let mut member_of = None;
+    let mut inline = false;
+    let mut start_address = None;
+    let mut end_address = None;
+    let mut virtual_ = false;
+    // as opposed to a higher base class whose function is beging overridden
+    let mut this_pointer_found = false;
+    let mut direct_base_key = None;
+    let mut const_ = false;
+    let mut volatile_ = false;
+    for attr in &tag.attributes {
+        match (attr.kind, &attr.value) {
+            (AttributeKind::Sibling, _) => {}
+            (AttributeKind::Name, AttributeValue::String(s)) => name = Some(s.clone()),
+            (AttributeKind::MwMangled, AttributeValue::String(s)) => mangled_name = Some(s.clone()),
+            (
+                AttributeKind::FundType
+                | AttributeKind::ModFundType
+                | AttributeKind::UserDefType
+                | AttributeKind::ModUDType,
+                _,
+            ) => return_type = Some(process_type(attr, info.e)?),
+            (AttributeKind::Prototyped, _) => prototyped = true,
+            (AttributeKind::LowPc, &AttributeValue::Address(addr)) => {
+                start_address = Some(addr);
+            }
+            (AttributeKind::HighPc, &AttributeValue::Address(addr)) => {
+                end_address = Some(addr);
+            }
+            (AttributeKind::MwGlobalRef, &AttributeValue::Reference(_)) => {}
+            (AttributeKind::MwGlobalRefsBlock, AttributeValue::Block(_)) => {
+                // Global references block
+            }
+            (AttributeKind::ReturnAddr, AttributeValue::Block(_block)) => {}
+            (AttributeKind::Member, &AttributeValue::Reference(key)) => {
+                member_of = Some(key);
+            }
+            (AttributeKind::MwPrologueEnd, &AttributeValue::Address(_addr)) => {
+                // Prologue end
+            }
+            (AttributeKind::MwEpilogueStart, &AttributeValue::Address(_addr)) => {
+                // Epilogue start
+            }
+            (
+                AttributeKind::MwRestoreSp
+                | AttributeKind::MwRestoreS0
+                | AttributeKind::MwRestoreS1
+                | AttributeKind::MwRestoreS2
+                | AttributeKind::MwRestoreS3
+                | AttributeKind::MwRestoreS4
+                | AttributeKind::MwRestoreS5
+                | AttributeKind::MwRestoreS6
+                | AttributeKind::MwRestoreS7
+                | AttributeKind::MwRestoreS8
+                | AttributeKind::MwRestoreF20
+                | AttributeKind::MwRestoreF21
+                | AttributeKind::MwRestoreF22
+                | AttributeKind::MwRestoreF23
+                | AttributeKind::MwRestoreF24
+                | AttributeKind::MwRestoreF25
+                | AttributeKind::MwRestoreF26
+                | AttributeKind::MwRestoreF27
+                | AttributeKind::MwRestoreF28
+                | AttributeKind::MwRestoreF29
+                | AttributeKind::MwRestoreF30,
+                AttributeValue::Block(_),
+            ) => {
+                // Restore register
+            }
+            (AttributeKind::Inline, _) => inline = true,
+            (AttributeKind::Virtual, _) => virtual_ = true,
+            (AttributeKind::Specification, &AttributeValue::Reference(key)) => {
+                let spec_tag = info
+                    .tags
+                    .get(&key)
+                    .ok_or_else(|| anyhow!("Failed to locate specification tag {}", key))?;
+                // Merge attributes from specification tag
+                let spec = process_subroutine_tag(info, spec_tag)?;
+                name = name.or(spec.name);
+                mangled_name = mangled_name.or(spec.mangled_name);
+                return_type = return_type.or(Some(spec.return_type));
+                prototyped = prototyped || spec.prototyped;
+                parameters.extend(spec.parameters);
+                var_args = var_args || spec.var_args;
+                member_of = member_of.or(spec.member_of);
+                inline = inline || spec.inline;
+                virtual_ = virtual_ || spec.virtual_;
+            }
+            _ => {
+                bail!("Unhandled SubroutineType attribute {:?}", attr);
+            }
+        }
+    }
+
+    for child in tag.children(&info.tags) {
+        match child.kind {
+            TagKind::FormalParameter => {
+                let param = process_subroutine_parameter_tag(info, child)?;
+                if !this_pointer_found && param.name.as_deref() == Some("this") {
+                    let modifiers = &param.kind.modifiers;
+                    if modifiers.len() >= 3
+                        && modifiers[0] == Modifier::Const
+                        && modifiers[2] == Modifier::Const
+                    {
+                        const_ = true;
+                    }
+                    if modifiers.contains(&Modifier::Volatile) {
+                        volatile_ = true;
+                    }
+                    // This is needed because direct_base differs from member_of in virtual function overrides
+                    if let TypeKind::UserDefined(key) = param.kind.kind {
+                        direct_base_key = Some(key);
+                    }
+                    this_pointer_found = true;
+                }
+                // Avoid applying ones that were already in the specification
+                if !parameters.iter().any(|p| {
+                    matches!(
+                        (p.name.as_ref(), param.name.as_ref()),
+                        (Some(a), Some(b)) if a == b
+                    )
+                }) {
+                    parameters.push(param);
+                }
+            }
+            TagKind::UnspecifiedParameters
+            | TagKind::LocalVariable
+            | TagKind::GlobalVariable
+            | TagKind::Label
+            | TagKind::LexicalBlock
+            | TagKind::InlinedSubroutine
+            | TagKind::StructureType
+            | TagKind::EnumerationType
+            | TagKind::UnionType
+            | TagKind::Typedef
+            | TagKind::ArrayType
+            | TagKind::SubroutineType
+            | TagKind::PtrToMemberType => {}
+            kind => bail!("Unhandled SubroutineType child {:?}", kind),
+        }
+    }
+
+    let return_type = return_type
+        .unwrap_or_else(|| Type { kind: TypeKind::Fundamental(FundType::Void), modifiers: vec![] });
+    let direct_member_of = direct_base_key;
+    let local = tag.kind == TagKind::Subroutine;
+
+    let mut static_member = false;
+    if let Producer::GCC = info.producer {
+        // GCC doesn't retain namespaces, so this is a nice way to determine staticness
+        static_member = member_of.is_some() && !this_pointer_found;
+    }
+    let override_ = virtual_ && member_of != direct_member_of;
+    let subroutine = MemberSubroutineDefType {
+        name,
+        mangled_name,
+        return_type,
+        parameters,
+        var_args,
+        prototyped,
+        member_of,
+        direct_member_of,
+        inline,
+        virtual_,
+        local,
+        start_address,
+        end_address,
+        const_,
+        static_member,
+        override_,
+        volatile_,
+    };
+    Ok(subroutine)
+}
+
 fn process_subroutine_tag(info: &DwarfInfo, tag: &Tag) -> Result<SubroutineType> {
     ensure!(
         matches!(
@@ -2231,6 +2928,11 @@ fn process_subroutine_tag(info: &DwarfInfo, tag: &Tag) -> Result<SubroutineType>
     let mut start_address = None;
     let mut end_address = None;
     let mut virtual_ = false;
+    // as opposed to a higher base class whose function is beging overridden
+    let mut this_pointer_found = false;
+    let mut direct_base_key = None;
+    let mut const_ = false;
+    let mut volatile_ = false;
     for attr in &tag.attributes {
         match (attr.kind, &attr.value) {
             (AttributeKind::Sibling, _) => {}
@@ -2323,12 +3025,39 @@ fn process_subroutine_tag(info: &DwarfInfo, tag: &Tag) -> Result<SubroutineType>
 
     let mut variables = Vec::new();
     let mut labels = Vec::new();
-    let mut blocks = Vec::new();
-    let mut inlines = Vec::new();
+    let mut blocks_and_inlines = Vec::new();
+    let mut inner_types = Vec::new();
+    let mut typedefs = Vec::new();
     for child in tag.children(&info.tags) {
         match child.kind {
             TagKind::FormalParameter => {
-                parameters.push(process_subroutine_parameter_tag(info, child)?)
+                let param = process_subroutine_parameter_tag(info, child)?;
+                if !this_pointer_found && param.name.as_deref() == Some("this") {
+                    let modifiers = &param.kind.modifiers;
+                    if modifiers.len() >= 3
+                        && modifiers[0] == Modifier::Const
+                        && modifiers[2] == Modifier::Const
+                    {
+                        const_ = true;
+                    }
+                    if modifiers.contains(&Modifier::Volatile) {
+                        volatile_ = true;
+                    }
+                    // This is needed because direct_base differs from member_of in virtual function overrides
+                    if let TypeKind::UserDefined(key) = param.kind.kind {
+                        direct_base_key = Some(key);
+                    }
+                    this_pointer_found = true;
+                }
+                // Avoid applying ones that were already in the specification
+                if !parameters.iter().any(|p| {
+                    matches!(
+                        (p.name.as_ref(), param.name.as_ref()),
+                        (Some(a), Some(b)) if a == b
+                    )
+                }) {
+                    parameters.push(param);
+                }
             }
             TagKind::UnspecifiedParameters => var_args = true,
             TagKind::LocalVariable => variables.push(process_local_variable_tag(info, child)?),
@@ -2338,18 +3067,21 @@ fn process_subroutine_tag(info: &DwarfInfo, tag: &Tag) -> Result<SubroutineType>
             TagKind::Label => labels.push(process_subroutine_label_tag(info, child)?),
             TagKind::LexicalBlock => {
                 if let Some(block) = process_subroutine_block_tag(info, child)? {
-                    blocks.push(block);
+                    blocks_and_inlines.push(SubroutineNode::Block(block));
                 }
             }
-            TagKind::InlinedSubroutine => inlines.push(process_subroutine_tag(info, child)?),
-            TagKind::StructureType
-            | TagKind::ArrayType
-            | TagKind::EnumerationType
-            | TagKind::UnionType
-            | TagKind::ClassType
-            | TagKind::SubroutineType
-            | TagKind::PtrToMemberType
-            | TagKind::Typedef => {
+            TagKind::InlinedSubroutine => blocks_and_inlines
+                .push(SubroutineNode::Inline(process_subroutine_tag(info, child)?)),
+            TagKind::StructureType | TagKind::ClassType => {
+                inner_types.push(UserDefinedType::Structure(process_structure_tag(info, child)?))
+            }
+            TagKind::EnumerationType => inner_types
+                .push(UserDefinedType::Enumeration(process_enumeration_tag(info, child)?)),
+            TagKind::UnionType => {
+                inner_types.push(UserDefinedType::Union(process_union_tag(info, child)?))
+            }
+            TagKind::Typedef => typedefs.push(process_typedef_tag(info, child)?),
+            TagKind::ArrayType | TagKind::SubroutineType | TagKind::PtrToMemberType => {
                 // Variable type, ignore
             }
             kind => bail!("Unhandled SubroutineType child {:?}", kind),
@@ -2358,8 +3090,16 @@ fn process_subroutine_tag(info: &DwarfInfo, tag: &Tag) -> Result<SubroutineType>
 
     let return_type = return_type
         .unwrap_or_else(|| Type { kind: TypeKind::Fundamental(FundType::Void), modifiers: vec![] });
+    let direct_member_of = direct_base_key;
     let local = tag.kind == TagKind::Subroutine;
-    Ok(SubroutineType {
+
+    let mut static_member = false;
+    if let Producer::GCC = info.producer {
+        // GCC doesn't retain namespaces, so this is a nice way to determine staticness
+        static_member = member_of.is_some() && !this_pointer_found;
+    }
+    let override_ = virtual_ && member_of != direct_member_of;
+    let subroutine = SubroutineType {
         name,
         mangled_name,
         return_type,
@@ -2368,16 +3108,23 @@ fn process_subroutine_tag(info: &DwarfInfo, tag: &Tag) -> Result<SubroutineType>
         prototyped,
         references,
         member_of,
+        direct_member_of,
         variables,
         inline,
         virtual_,
         local,
         labels,
-        blocks,
-        inlines,
+        blocks_and_inlines,
+        inner_types,
+        typedefs,
         start_address,
         end_address,
-    })
+        const_,
+        static_member,
+        override_,
+        volatile_,
+    };
+    Ok(subroutine)
 }
 
 fn process_subroutine_label_tag(info: &DwarfInfo, tag: &Tag) -> Result<SubroutineLabel> {
@@ -2420,8 +3167,9 @@ fn process_subroutine_block_tag(info: &DwarfInfo, tag: &Tag) -> Result<Option<Su
     }
 
     let mut variables = Vec::new();
-    let mut blocks = Vec::new();
-    let mut inlines = Vec::new();
+    let mut blocks_and_inlines = Vec::new();
+    let mut inner_types = Vec::new();
+    let mut typedefs = Vec::new();
     for child in tag.children(&info.tags) {
         match child.kind {
             TagKind::LocalVariable => variables.push(process_local_variable_tag(info, child)?),
@@ -2430,26 +3178,42 @@ fn process_subroutine_block_tag(info: &DwarfInfo, tag: &Tag) -> Result<Option<Su
             }
             TagKind::LexicalBlock => {
                 if let Some(block) = process_subroutine_block_tag(info, child)? {
-                    blocks.push(block);
+                    blocks_and_inlines.push(SubroutineNode::Block(block));
                 }
             }
             TagKind::InlinedSubroutine => {
-                inlines.push(process_subroutine_tag(info, child)?);
+                blocks_and_inlines
+                    .push(SubroutineNode::Inline(process_subroutine_tag(info, child)?));
             }
-            TagKind::StructureType
-            | TagKind::ArrayType
-            | TagKind::EnumerationType
-            | TagKind::UnionType
-            | TagKind::ClassType
-            | TagKind::SubroutineType
-            | TagKind::PtrToMemberType => {
+            TagKind::StructureType | TagKind::ClassType => {
+                inner_types.push(UserDefinedType::Structure(process_structure_tag(info, child)?))
+            }
+            TagKind::EnumerationType => {
+                inner_types
+                    .push(UserDefinedType::Enumeration(process_enumeration_tag(info, child)?));
+            }
+            TagKind::UnionType => {
+                inner_types.push(UserDefinedType::Union(process_union_tag(info, child)?))
+            }
+            TagKind::Typedef => {
+                typedefs.push(process_typedef_tag(info, child)?);
+            }
+            TagKind::ArrayType | TagKind::SubroutineType | TagKind::PtrToMemberType => {
                 // Variable type, ignore
             }
             kind => bail!("Unhandled LexicalBlock child {:?}", kind),
         }
     }
 
-    Ok(Some(SubroutineBlock { name, start_address, end_address, variables, blocks, inlines }))
+    Ok(Some(SubroutineBlock {
+        name,
+        start_address,
+        end_address,
+        variables,
+        blocks_and_inlines,
+        inner_types,
+        typedefs,
+    }))
 }
 
 fn process_subroutine_parameter_tag(info: &DwarfInfo, tag: &Tag) -> Result<SubroutineParameter> {
@@ -2592,6 +3356,15 @@ fn process_ptr_to_member_tag(info: &DwarfInfo, tag: &Tag) -> Result<PtrToMemberT
     Ok(PtrToMemberType { kind, containing_type })
 }
 
+pub fn get_udt_by_key(info: &DwarfInfo, key: u32) -> Result<UserDefinedType> {
+    let tag = match info.tags.get(&key) {
+        Some(t) => t,
+        None => return Err(anyhow!("Failed to locate user defined type {}", key)),
+    };
+
+    ud_type(info, tag)
+}
+
 pub fn ud_type(info: &DwarfInfo, tag: &Tag) -> Result<UserDefinedType> {
     match tag.kind {
         TagKind::ArrayType => Ok(UserDefinedType::Array(process_array_tag(info, tag)?)),
@@ -2729,6 +3502,15 @@ pub fn process_overlay_branch(tag: &Tag) -> Result<OverlayBranch> {
     Ok(OverlayBranch { name, id, start_address, end_address, compile_unit })
 }
 
+pub fn preprocess_cu_tag(info: &DwarfInfo, tag: &Tag) {
+    match tag.kind {
+        TagKind::SubroutineType | TagKind::GlobalSubroutine | TagKind::Subroutine => {
+            let _ = preprocess_subroutine_tag(info, tag);
+        }
+        _ => {}
+    }
+}
+
 pub fn process_cu_tag(info: &DwarfInfo, tag: &Tag) -> Result<TagType> {
     match tag.kind {
         TagKind::Typedef => Ok(TagType::Typedef(process_typedef_tag(info, tag)?)),
@@ -2743,7 +3525,7 @@ pub fn process_cu_tag(info: &DwarfInfo, tag: &Tag) -> Result<TagType> {
         | TagKind::SubroutineType
         | TagKind::GlobalSubroutine
         | TagKind::Subroutine
-        | TagKind::PtrToMemberType => Ok(TagType::UserDefined(ud_type(info, tag)?)),
+        | TagKind::PtrToMemberType => Ok(TagType::UserDefined(Box::new(ud_type(info, tag)?))),
         kind => Err(anyhow!("Unhandled root tag type {:?}", kind)),
     }
 }
@@ -2768,7 +3550,7 @@ pub fn tag_type_string(
         TagType::Variable(v) => variable_string(info, typedefs, v, true),
         TagType::UserDefined(ud) => {
             let ud_str = ud_type_def(info, typedefs, ud, is_erased)?;
-            match ud {
+            match **ud {
                 UserDefinedType::Structure(_)
                 | UserDefinedType::Enumeration(_)
                 | UserDefinedType::Union(_) => Ok(format!("{ud_str};")),
@@ -2793,7 +3575,7 @@ fn variable_string(
     let mut out = if variable.local { "static ".to_string() } else { String::new() };
     out.push_str(&ts.prefix);
     out.push(' ');
-    out.push_str(variable.name.as_deref().unwrap_or("[unknown]"));
+    out.push_str(&maybe_demangle_name(info, variable.name.as_deref().unwrap_or("[unknown]")));
     out.push_str(&ts.suffix);
     out.push(';');
     if include_extra {
@@ -2822,6 +3604,19 @@ fn process_typedef_tag(info: &DwarfInfo, tag: &Tag) -> Result<TypedefTag> {
                 | AttributeKind::ModUDType,
                 _,
             ) => kind = Some(process_type(attr, info.e)?),
+            (AttributeKind::Member, _) => {
+                // can be ignored for now
+            }
+            (AttributeKind::Specification, &AttributeValue::Reference(key)) => {
+                let spec_tag = info
+                    .tags
+                    .get(&key)
+                    .ok_or_else(|| anyhow!("Failed to locate specification tag {}", key))?;
+                // Merge attributes from specification tag
+                let spec = process_typedef_tag(info, spec_tag)?;
+                name = name.or(Some(spec.name));
+                kind = kind.or(Some(spec.kind));
+            }
             _ => {
                 bail!("Unhandled Typedef attribute {:?}", attr);
             }
@@ -2838,11 +3633,13 @@ fn process_typedef_tag(info: &DwarfInfo, tag: &Tag) -> Result<TypedefTag> {
 }
 
 fn process_variable_tag(info: &DwarfInfo, tag: &Tag) -> Result<VariableTag> {
-    ensure!(
-        matches!(tag.kind, TagKind::GlobalVariable | TagKind::LocalVariable),
-        "{:?} is not a variable tag",
-        tag.kind
-    );
+    let is_variable = match tag.kind {
+        TagKind::GlobalVariable | TagKind::LocalVariable => true,
+        TagKind::Typedef if info.producer == Producer::MWCC => true,
+        _ => false,
+    };
+
+    ensure!(is_variable, "{:?} is not a variable tag", tag.kind);
 
     let mut name = None;
     let mut mangled_name = None;
@@ -2879,4 +3676,33 @@ fn process_variable_tag(info: &DwarfInfo, tag: &Tag) -> Result<VariableTag> {
     let kind = kind.ok_or_else(|| anyhow!("Variable without Type: {:?}", tag))?;
     let local = tag.kind == TagKind::LocalVariable;
     Ok(VariableTag { name, mangled_name, kind, address, local })
+}
+
+// TODO expand for more compilers?
+fn maybe_demangle_name(info: &DwarfInfo, name: &str) -> String {
+    let name_opt = match info.producer {
+        Producer::MWCC => cw_demangle(name, &Default::default()),
+        Producer::GCC => gnu_demangle(name, &DemangleConfig::new()).ok(),
+        Producer::OTHER => None,
+    };
+    name_opt.unwrap_or_else(|| name.to_string())
+}
+
+fn maybe_demangle_function_name(info: &DwarfInfo, name: &str) -> String {
+    let fake_name = format!("{}__0", name);
+    let name_opt = match info.producer {
+        // for __pl this looks like operator+
+        Producer::MWCC => cw_demangle(&fake_name, &Default::default()),
+        // for __pl this looks like ::operator+(void)
+        Producer::GCC => {
+            gnu_demangle(&fake_name, &DemangleConfig::new()).ok().and_then(|demangled| {
+                demangled
+                    .split_once("::")
+                    .and_then(|(_, rest)| rest.split_once("(void)"))
+                    .map(|(op, _)| op.to_string())
+            })
+        }
+        Producer::OTHER => None,
+    };
+    name_opt.unwrap_or_else(|| name.to_string())
 }

--- a/src/util/file.rs
+++ b/src/util/file.rs
@@ -144,7 +144,7 @@ pub fn touch(path: &Utf8NativePath) -> io::Result<()> {
     }
 }
 
-pub fn decompress_if_needed(buf: &[u8]) -> Result<Bytes> {
+pub fn decompress_if_needed(buf: &[u8]) -> Result<Bytes<'_>> {
     if buf.len() > 4 {
         match *array_ref!(buf, 0, 4) {
             YAZ0_MAGIC => return decompress_yaz0(buf).map(Bytes::Owned),

--- a/src/util/rarc.rs
+++ b/src/util/rarc.rs
@@ -200,7 +200,7 @@ impl<'a> RarcView<'a> {
     }
 
     /// Get a string from the string table at the given offset.
-    pub fn get_string(&self, offset: u32) -> Result<Cow<str>, String> {
+    pub fn get_string(&self, offset: u32) -> Result<Cow<'_, str>, String> {
         let name_buf = self.string_table.get(offset as usize..).ok_or_else(|| {
             format!(
                 "RARC: name offset {} out of bounds (string table size: {})",

--- a/src/util/split.rs
+++ b/src/util/split.rs
@@ -10,11 +10,11 @@ use sanitise_file_name::sanitize_with_options;
 use tracing_attributes::instrument;
 
 use crate::{
-    analysis::{cfa::SectionAddress, read_address, read_u32},
+    analysis::{cfa::SectionAddress, read_address, read_u32, relocation_target_for},
     obj::{
-        ObjArchitecture, ObjInfo, ObjKind, ObjReloc, ObjRelocations, ObjSection, ObjSectionKind,
-        ObjSplit, ObjSymbol, ObjSymbolFlagSet, ObjSymbolFlags, ObjSymbolKind, ObjSymbolScope,
-        ObjUnit, SectionIndex, SymbolIndex,
+        ObjArchitecture, ObjInfo, ObjKind, ObjReloc, ObjRelocKind, ObjRelocations, ObjSection,
+        ObjSectionKind, ObjSplit, ObjSymbol, ObjSymbolFlagSet, ObjSymbolFlags, ObjSymbolKind,
+        ObjSymbolScope, ObjUnit, SectionIndex, SymbolIndex,
     },
     util::{align_up, comment::MWComment, toposort::toposort},
 };
@@ -33,7 +33,9 @@ fn split_ctors_dtors(obj: &mut ObjInfo, start: SectionAddress, end: SectionAddre
 
     while current_address < end {
         // ProDG hack when the end address is not known
-        if matches!(read_u32(ctors_section, current_address.address), Some(0)) {
+        if matches!(read_u32(ctors_section, current_address.address), Some(0))
+            && relocation_target_for(obj, current_address, Some(ObjRelocKind::Absolute))?.is_none()
+        {
             while current_address < end {
                 ensure!(
                     matches!(read_u32(ctors_section, current_address.address), Some(0)),
@@ -528,8 +530,7 @@ fn validate_splits(obj: &ObjInfo) -> Result<()> {
         if let Some((_, symbol)) = obj
             .symbols
             .for_section_range(section_index, ..addr)
-            .filter(|&(_, s)| s.size_known && s.size > 0 && !s.flags.is_stripped())
-            .next_back()
+            .rfind(|&(_, s)| s.size_known && s.size > 0 && !s.flags.is_stripped())
         {
             ensure!(
                 addr >= symbol.address as u32 + symbol.size as u32,
@@ -547,8 +548,7 @@ fn validate_splits(obj: &ObjInfo) -> Result<()> {
         if let Some((_, symbol)) = obj
             .symbols
             .for_section_range(section_index, ..split.end)
-            .filter(|&(_, s)| s.size_known && s.size > 0 && !s.flags.is_stripped())
-            .next_back()
+            .rfind(|&(_, s)| s.size_known && s.size > 0 && !s.flags.is_stripped())
         {
             ensure!(
                 split.end >= symbol.address as u32 + symbol.size as u32,
@@ -771,8 +771,7 @@ fn trim_split_alignment(obj: &mut ObjInfo) -> Result<()> {
         if let Some((_, symbol)) = obj
             .symbols
             .for_section_range(section_index, addr..split.end)
-            .filter(|&(_, s)| s.size_known && s.size > 0 && !s.flags.is_stripped())
-            .next_back()
+            .rfind(|&(_, s)| s.size_known && s.size > 0 && !s.flags.is_stripped())
         {
             split_end = symbol.address as u32 + symbol.size as u32;
         }
@@ -1057,7 +1056,11 @@ fn resolve_link_order(obj: &ObjInfo) -> Result<Vec<ObjUnit>> {
 
 /// Split an object into multiple relocatable objects.
 #[instrument(level = "debug", skip(obj))]
-pub fn split_obj(obj: &ObjInfo, module_name: Option<&str>) -> Result<Vec<ObjInfo>> {
+pub fn split_obj(
+    obj: &ObjInfo,
+    module_name: Option<&str>,
+    globalize_symbols: bool,
+) -> Result<Vec<ObjInfo>> {
     let mut objects: Vec<ObjInfo> = vec![];
     let mut object_symbols: Vec<Vec<Option<SymbolIndex>>> = vec![];
     let mut name_to_obj: HashMap<String, usize> = HashMap::new();
@@ -1280,7 +1283,7 @@ pub fn split_obj(obj: &ObjInfo, module_name: Option<&str>) -> Result<Vec<ObjInfo
     }
 
     // Update relocations
-    let mut globalize_symbols = vec![];
+    let mut symbols_to_globalize = vec![];
     for (obj_idx, out_obj) in objects.iter_mut().enumerate() {
         let symbol_idxs = &mut object_symbols[obj_idx];
         for (_section_index, section) in out_obj.sections.iter_mut() {
@@ -1296,7 +1299,7 @@ pub fn split_obj(obj: &ObjInfo, module_name: Option<&str>) -> Result<Vec<ObjInfo
 
                         // If the symbol is local, we'll upgrade the scope to global
                         // and rename it to avoid conflicts
-                        if target_sym.flags.is_local() {
+                        if globalize_symbols && target_sym.flags.is_local() {
                             let address_str = if obj.module_id == 0 {
                                 format!("{:08X}", target_sym.address)
                             } else if let Some(section_index) = target_sym.section {
@@ -1315,7 +1318,7 @@ pub fn split_obj(obj: &ObjInfo, module_name: Option<&str>) -> Result<Vec<ObjInfo
                             } else {
                                 format!("{}_{}", target_sym.name, address_str)
                             };
-                            globalize_symbols.push((reloc.target_symbol, new_name));
+                            symbols_to_globalize.push((reloc.target_symbol, new_name));
                         }
 
                         symbol_idxs[reloc.target_symbol as usize] = Some(out_sym_idx);
@@ -1360,16 +1363,18 @@ pub fn split_obj(obj: &ObjInfo, module_name: Option<&str>) -> Result<Vec<ObjInfo
     }
 
     // Upgrade local symbols to global if necessary
-    for (obj, symbol_map) in objects.iter_mut().zip(&object_symbols) {
-        for (globalize_idx, new_name) in &globalize_symbols {
-            if let Some(symbol_idx) = symbol_map[*globalize_idx as usize] {
-                let mut symbol = obj.symbols[symbol_idx].clone();
-                symbol.name.clone_from(new_name);
-                if symbol.flags.is_local() {
-                    log::debug!("Globalizing {} in {}", symbol.name, obj.name);
-                    symbol.flags.set_scope(ObjSymbolScope::Global);
+    if globalize_symbols {
+        for (obj, symbol_map) in objects.iter_mut().zip(&object_symbols) {
+            for (globalize_idx, new_name) in &symbols_to_globalize {
+                if let Some(symbol_idx) = symbol_map[*globalize_idx as usize] {
+                    let mut symbol = obj.symbols[symbol_idx].clone();
+                    symbol.name.clone_from(new_name);
+                    if symbol.flags.is_local() {
+                        log::debug!("Globalizing {} in {}", symbol.name, obj.name);
+                        symbol.flags.set_scope(ObjSymbolScope::Global);
+                    }
+                    obj.symbols.replace(symbol_idx, symbol)?;
                 }
-                obj.symbols.replace(symbol_idx, symbol)?;
             }
         }
     }
@@ -1498,16 +1503,13 @@ pub fn end_for_section(obj: &ObjInfo, section_index: SectionIndex) -> Result<Sec
         section_end -= 4;
     }
     loop {
-        let last_symbol = obj
-            .symbols
-            .for_section_range(section_index, ..section_end)
-            .filter(|(_, s)| {
+        let last_symbol =
+            obj.symbols.for_section_range(section_index, ..section_end).rfind(|(_, s)| {
                 s.kind == ObjSymbolKind::Object
                     && s.size_known
                     && s.size > 0
                     && !s.flags.is_stripped()
-            })
-            .next_back();
+            });
         match last_symbol {
             Some((_, symbol)) if is_linker_generated_object(&symbol.name) => {
                 log::debug!(
@@ -1541,8 +1543,8 @@ fn auto_unit_name(
         length_limit: 20,
         ..Default::default()
     })
-    // Also replace $ to avoid issues with build.ninja
-    .replace('$', "_");
+    // Also replace characters that break downstream tooling (build.ninja, linker, etc)
+    .replace(['$', ','], "_");
     let mut unit_name = format!("auto_{}_{}", name, section_name.trim_start_matches('.'));
     // Ensure the name is unique
     if unit_exists(&unit_name, obj, new_splits) {

--- a/src/util/u8_arc.rs
+++ b/src/util/u8_arc.rs
@@ -121,10 +121,10 @@ impl<'a> U8View<'a> {
     }
 
     /// Iterate over the nodes in the U8 archive.
-    pub fn iter(&self) -> U8Iter { U8Iter { inner: self, idx: 1 } }
+    pub fn iter(&self) -> U8Iter<'_> { U8Iter { inner: self, idx: 1 } }
 
     /// Get the name of a node.
-    pub fn get_name(&self, node: U8Node) -> Result<Cow<str>, String> {
+    pub fn get_name(&self, node: U8Node) -> Result<Cow<'_, str>, String> {
         let name_buf = self.string_table.get(node.name_offset() as usize..).ok_or_else(|| {
             format!(
                 "U8: name offset {} out of bounds (string table size: {})",

--- a/src/vfs/common.rs
+++ b/src/vfs/common.rs
@@ -89,7 +89,9 @@ impl Read for WindowedFile {
             return Ok(0);
         }
         let len = buf.len().min(remaining as usize);
-        self.base.read(&mut buf[..len])
+        let n = self.base.read(&mut buf[..len])?;
+        self.pos += n as u64;
+        Ok(n)
     }
 }
 

--- a/src/vfs/disc.rs
+++ b/src/vfs/disc.rs
@@ -47,7 +47,7 @@ impl DiscFs {
         Ok(Self { disc, base, meta, mtime })
     }
 
-    fn find(&self, path: &Utf8UnixPath) -> VfsResult<DiscNode> {
+    fn find(&self, path: &Utf8UnixPath) -> VfsResult<DiscNode<'_>> {
         let path = path.as_str().trim_matches('/');
         let mut split = path.split('/');
         let mut segment = next_non_empty(&mut split);

--- a/src/vfs/rarc.rs
+++ b/src/vfs/rarc.rs
@@ -13,7 +13,7 @@ pub struct RarcFs {
 impl RarcFs {
     pub fn new(file: Box<dyn VfsFile>) -> io::Result<Self> { Ok(Self { file }) }
 
-    fn view(&mut self) -> io::Result<RarcView> {
+    fn view(&mut self) -> io::Result<RarcView<'_>> {
         let data = self.file.map()?;
         RarcView::new(data).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
     }

--- a/src/vfs/u8_arc.rs
+++ b/src/vfs/u8_arc.rs
@@ -13,7 +13,7 @@ pub struct U8Fs {
 impl U8Fs {
     pub fn new(file: Box<dyn VfsFile>) -> io::Result<Self> { Ok(Self { file }) }
 
-    fn view(&mut self) -> io::Result<U8View> {
+    fn view(&mut self) -> io::Result<U8View<'_>> {
         let data = self.file.map()?;
         U8View::new(data).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
     }

--- a/src/vfs/wad.rs
+++ b/src/vfs/wad.rs
@@ -41,7 +41,7 @@ impl WadFs {
         Ok(Self { file, wad, mtime })
     }
 
-    fn find(&self, path: &str) -> Option<WadFindResult> {
+    fn find(&self, path: &str) -> Option<WadFindResult<'_>> {
         let filename = path.trim_start_matches('/');
         if filename.contains('/') {
             return None;


### PR DESCRIPTION
## Summary
- Merges 26 commits from encounter/decomp-toolkit (v1.6.2 → v1.8.0)
- Key upstream additions: skip_cfa_ranges, SDA symbol creation, jump table validation fixes, globalize_symbols, dependency updates
- Preserves all XEX-specific analysis and jeff's custom dependencies

## Conflict resolutions
- Cargo.toml: kept jeff's git fork deps, took upstream's new deps
- cfa.rs: kept `as u32` casts, added upstream's SDA symbol creation
- slices.rs: took upstream's `max_block` jump table validation
- xex.rs: added `globalize_symbols: false` to split_obj calls
- Kept deleted: dwarf.rs, elf.rs, elf2dol.rs, rel.rs (GC/Wii-only)

## Testing
- `cargo build --release` succeeds
- `cargo test` passes
- dc3-decomp ninja build completes without panics

I'll keep banging on this as I work through my decomp workflows. I've got a whole fork full of stuff that you're welcome to review. Hopefully this is relatively light and helpful though 🙏 