### PR TITLE
Refactor basic RTTI labeling routine

### DIFF
--- a/src/analysis/objects.rs
+++ b/src/analysis/objects.rs
@@ -183,14 +183,6 @@ pub fn detect_strings(obj: &mut ObjInfo) -> Result<()> {
     for entry in symbols_set.iter() {
         let mut symbol = obj.symbols[entry.idx].clone();
 
-        // if we see a string involving dynamic casting, we've got RTTI
-        // this specific string is thrown in an std::exception, so it should also be detectable in retail builds
-        if let Some(the_string) = &entry.demangled_name {
-            if the_string == "Bad dynamic_cast!" {
-                obj.rtti = true;
-            }
-        }
-
         // TODO: create an MSVC mangled representation of the string, and have that be the new symbol name
         symbol.name = format!("str_{:08X}", symbol.address as u32);
         log::debug!("Setting {} ({:#010X}) to size {:#X}", symbol.name, symbol.address, entry.size);

--- a/src/analysis/pass.rs
+++ b/src/analysis/pass.rs
@@ -46,18 +46,19 @@ impl AnalysisPass for FindSaveRestSledsXbox {
                     );
                 }
                 // add known symbols for them
-                if obj.known_functions.contains_key(&start) {
-                    let known_func_size = obj.known_functions.get(&start).unwrap().unwrap();
-                    state.known_symbols.entry(start).or_default().push(ObjSymbol {
-                        name: func.to_string(),
-                        address: start.address as u64,
-                        section: Some(start.section),
-                        size: known_func_size as u64,
-                        size_known: true,
-                        flags: ObjSymbolFlagSet(ObjSymbolFlags::Global.into()),
-                        kind: ObjSymbolKind::Function,
-                        ..Default::default()
-                    });
+                if let Some(known_func) = obj.known_functions.get(&start) {
+                    if let Some(known_func_size) = known_func {
+                        state.known_symbols.entry(start).or_default().push(ObjSymbol {
+                            name: func.to_string(),
+                            address: start.address as u64,
+                            section: Some(start.section),
+                            size: known_func_size.clone() as u64,
+                            size_known: true,
+                            flags: ObjSymbolFlagSet(ObjSymbolFlags::Global.into()),
+                            kind: ObjSymbolKind::Function,
+                            ..Default::default()
+                        });
+                    }
                 }
                 for i in reg_start..reg_end {
                     let addr = start + (i - reg_start) * step_size;

--- a/src/analysis/rtti.rs
+++ b/src/analysis/rtti.rs
@@ -68,11 +68,6 @@ struct RTTIMetadata {
     pub discovered_classes: Vec<Rc<RefCell<RTTIClass>>>,
 }
 
-// what if we had RTTI scanning here instead? before any CFA?
-// you can find Type Descriptors from: .?AU, .?AV, .PAU, .PAV
-// doing it here gives you more control over what size the symbols are
-// doing it in here would also mean no SymbolIndex, since we're not replacing symbols, we're adding them
-
 // Parse our ObjInfo for all the RTTI structures we can find.
 // Add labels for RTTI structures as we find them (eager approach), except for COLs, as we'll be analyzing them specially later.
 fn find_all_rtti_structs(
@@ -530,6 +525,9 @@ fn compute_superclass_info(
 pub struct FindRTTIObjectsXbox {}
 
 impl AnalysisPass for FindRTTIObjectsXbox {
+    // Scan for RTTI objects, before any CFA is performed.
+    // Allows us to mark them as known_symbols ahead of time, we have control over what the symbol sizes/scopes should be,
+    // and by stepping through vftables, we have more known function start addresses we can provide to our object.
     fn execute(state: &mut AnalyzerState, obj: &ObjInfo) -> Result<()> {
         let mut rtti_metadata = RTTIMetadata { discovered_classes: vec![] };
 

--- a/src/analysis/rtti.rs
+++ b/src/analysis/rtti.rs
@@ -47,6 +47,8 @@ struct CompleteObjectLocator {
     pub owner: Weak<RefCell<RTTIClass>>,
     // The address of the vftable associated with this COL
     pub vftable_addr: u32,
+    // how many entries the vftable has
+    pub num_vftable_entries: u32,
 }
 
 // A class that uses RTTI
@@ -55,7 +57,7 @@ struct RTTIClass {
     pub name: String, // this class's name, inferred from the type descriptor
     pub type_descriptor_addr: u32, // type descriptor addr in the exe
     // Make this an Option because some RTTIClasses can legit just only have a Type Descriptor and nothing else
-    pub class_hierarchy_descriptor: Option<Rc<ClassHierarchyDescriptor>>, // TODO: this could be a plain ole CHD? No Rc?
+    pub class_hierarchy_descriptor: Option<ClassHierarchyDescriptor>,
     // But, it can have multiple base classes, each with their own COL and vftable
     pub complete_object_locators: Vec<CompleteObjectLocator>,
     // TODO: add a field for base classes/direct bases when walking the inheritance tree
@@ -148,6 +150,11 @@ fn find_all_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<bool>
         unreachable!("No .rdata section???");
     };
 
+    // for calculating vftable sizes
+    let Some((_, text_section)) = obj.sections.by_name(".text")? else {
+        unreachable!("No .text section???");
+    };
+
     // now, search for COLs after the TDs (BCDs can't be found reliably, they can conflict with catchables)
     let mut i = 0;
     let data = &rdata_section.data;
@@ -187,11 +194,30 @@ fn find_all_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<bool>
                 }
 
                 // search for col_start_addr in .rdata
-                if let Some(vftable_idx) = memmem::find(data, &col_start_addr.to_be_bytes()) {
+                if let Some(col_start_idx) = memmem::find(data, &col_start_addr.to_be_bytes()) {
                     // the vftable is the next addr over from the COL, hence the +4
-                    let vftable_addr = rdata_section.address as u32 + vftable_idx as u32 + 4;
+                    let vftable_idx = col_start_idx + 4;
+                    let vftable_addr = rdata_section.address as u32 + vftable_idx as u32;
 
-                    // TODO: calculate vftable length here? add a field for it to CompleteObjectLocator?
+                    // calculate vftable entry count here
+                    // as long as an entry is a valid address in .text, keep going
+                    let mut num_vftable_entries: u32 = 0;
+                    loop {
+                        let cur_vftable_idx_offset =
+                            vftable_idx + (num_vftable_entries as usize * 4);
+                        let cur_vftable_entry = u32::from_be_bytes(
+                            data[cur_vftable_idx_offset..cur_vftable_idx_offset + 4].try_into()?,
+                        );
+                        // check that cur_vftable_entry is within .text bounds
+                        if text_section.address as u32 <= cur_vftable_entry
+                            && cur_vftable_entry
+                                < text_section.address as u32 + text_section.size as u32
+                        {
+                            num_vftable_entries += 1;
+                        } else {
+                            break;
+                        }
+                    }
 
                     // log::debug!(
                     //     "VFTable for COL at {:08X} found! It's at {:08X}",
@@ -206,6 +232,7 @@ fn find_all_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<bool>
                         cd_offset: u32::from_be_bytes(data[i - 4..i].try_into()?),
                         owner: Rc::downgrade(&rtti_class),
                         vftable_addr,
+                        num_vftable_entries,
                     };
                     assert_eq!(
                         col.signature, 0,
@@ -235,7 +262,7 @@ fn find_all_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<bool>
     let mut bcds_by_exe_addr: BTreeMap<u32, Rc<BaseClassDescriptor>> = BTreeMap::new();
 
     for (chd_exe_addr, the_rtti_class) in classes_by_chd_exe_addr {
-        log::debug!("CHD found at {:08X} for {}!", chd_exe_addr, the_rtti_class.borrow().name);
+        // log::debug!("CHD found at {:08X} for {}!", chd_exe_addr, the_rtti_class.borrow().name);
         // navigate to the bytes in .rdata that make up this CHD, and parse it
         let chd_data_idx = chd_exe_addr - rdata_section.address as u32;
         let chd_data = &rdata_section.data[chd_data_idx as usize..chd_data_idx as usize + 16];
@@ -273,13 +300,12 @@ fn find_all_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<bool>
                     let bcd_data_idx = cur_bcd_addr - rdata_section.address as u32;
                     let bcd_data =
                         &rdata_section.data[bcd_data_idx as usize..bcd_data_idx as usize + 28];
-                    // assert that the type descriptor at data[0..4] corresponds to the_rtti_class
                     let td_addr = u32::from_be_bytes(bcd_data[0..4].try_into()?);
                     let Some(class_for_bcd) = classes_by_type_descriptor_exe_addr.get(&td_addr)
                     else {
                         panic!("Bad Type Descriptor addr {:08X}!", td_addr);
                     };
-                    let bcd = BaseClassDescriptor {
+                    let bcd_ptr = Rc::new(BaseClassDescriptor {
                         addr: cur_bcd_addr,
                         num_contained_bases: u32::from_be_bytes(bcd_data[4..8].try_into()?),
                         m_disp: i32::from_be_bytes(bcd_data[8..12].try_into()?),
@@ -287,8 +313,7 @@ fn find_all_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<bool>
                         v_disp: i32::from_be_bytes(bcd_data[16..20].try_into()?),
                         attributes: u32::from_be_bytes(bcd_data[20..24].try_into()?),
                         owner: Rc::downgrade(&class_for_bcd),
-                    };
-                    let bcd_ptr = Rc::new(bcd);
+                    });
                     entry.insert(bcd_ptr.clone());
                     bcd_ptr
                 }
@@ -300,7 +325,7 @@ fn find_all_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<bool>
             chd.base_class_descriptors.push(cur_bcd.clone());
         }
 
-        the_rtti_class.borrow_mut().class_hierarchy_descriptor = Some(Rc::new(chd));
+        the_rtti_class.borrow_mut().class_hierarchy_descriptor = Some(chd);
     }
 
     Ok(true)

--- a/src/analysis/rtti.rs
+++ b/src/analysis/rtti.rs
@@ -1,921 +1,185 @@
-use std::collections::BTreeMap;
+use std::{
+    cell::RefCell,
+    collections::BTreeMap,
+    rc::{Rc, Weak},
+};
 
 use anyhow::Result;
 
-use crate::obj::{ObjInfo, SymbolIndex};
-
-// Info pertaining to an RTTI Object in the analyzed exe.
-#[derive(Clone, Debug)]
-struct RTTIExeInfo {
-    pub symbol_index: SymbolIndex, // the symbol index of this RTTI Object (for labeling)
-    pub addr: u32,                 // the address in the exe of this RTTI Object
-}
-
-// An RTTI Type Descriptor.
-struct TypeDescriptor {
-    pub exe_info: RTTIExeInfo,
-    pub name: String, // the object's class name
-}
+use crate::{
+    analysis::{cfa::AnalyzerState, pass::AnalysisPass},
+    obj::ObjInfo,
+};
 
 // An RTTI Base Class Descriptor Object.
 struct BaseClassDescriptor {
-    pub exe_info: RTTIExeInfo,
-    pub type_descriptor_addr: u32, // type descriptor of the class
-    pub num_contained_bases: u32,  // number of nested classes following in the Base Class Array
-    pub m_disp: i32,               // member displacement
-    pub p_disp: i32,               // vbtable displacement
-    pub v_disp: i32,               // displacement inside vbtable
+    pub addr: u32,                        // the address of this in the exe
+    pub type_descriptor: Weak<RTTIClass>, // type descriptor of the class
+    pub num_contained_bases: u32, // number of nested classes following in the Base Class Array
+    pub m_disp: i32,              // member displacement
+    pub p_disp: i32,              // vbtable displacement
+    pub v_disp: i32,              // displacement inside vbtable
     pub attributes: u32, // flags: 0x40 bit means has Class Hierarchy Descriptor, 0x10 bit means base class is virtually inherited
-    pub class_hierarchy_descriptor_addr: u32,
+    pub class_hierarchy_descriptor: Weak<ClassHierarchyDescriptor>,
 }
 
-// An RTTI Base Class Array object.
-struct BaseClassArray {
-    pub exe_info: RTTIExeInfo,
-    pub base_class_descriptors: Vec<u32>, // the addresses of the BCDs that make up this Base Class Array
-}
-
-// An RTTI Class Hierarchy Descriptor object.
+// An RTTI Class Hierarchy Descriptor object. Also contains Base Class Array information.
 struct ClassHierarchyDescriptor {
-    pub exe_info: RTTIExeInfo,
+    pub addr: u32,                  // the address of this in the exe
     pub signature: u32,             // always 0
     pub attributes: u32, // bit 0 set = multiple inheritance, bit 1 set = virtual inheritance
     pub num_base_classes: u32, // number of entries in the Base Class Array
-    pub base_class_array_addr: u32, // addr of the Base Class Array
+    pub base_class_array_addr: u32, // BCA addr in the exe
+    pub base_class_descriptors: Vec<Rc<BaseClassDescriptor>>, // the addresses of the BCDs that make up this Base Class Array
 }
 
 // An RTTI Complete Object Locator.
 struct CompleteObjectLocator {
-    pub exe_info: RTTIExeInfo,
+    pub addr: u32,      // the address of this in the exe
     pub signature: u32, // always 0
     pub offset: u32,    // offset of this vtable in complete class (from top)
     pub cd_offset: u32, // offset of constructor displacement
-    pub type_descriptor_addr: u32,
-    pub class_hierarchy_descriptor_addr: u32,
-    // The vftable associated with this COL
+    pub type_descriptor: Weak<RTTIClass>,
+    pub class_hierarchy_descriptor: Weak<ClassHierarchyDescriptor>,
+    // The address of the vftable associated with this COL
     pub vftable_addr: u32,
-}
-
-// A virtual function table.
-struct VFTable {
-    pub exe_info: RTTIExeInfo,
-}
-
-#[derive(Clone)]
-enum InheritanceKind {
-    // if physical, keep track of the m_disp
-    Physical(i32),
-    // i dunno what to keep track of for virtual yet
-    Virtual,
-}
-
-// Info for a base class of an RTTIClass.
-// Used for both applying final symbol labels, and for analysis of future derived RTTIClasses.
-#[derive(Clone)]
-struct RTTIBaseClass {
-    // the specific Type Descriptor for this superclass
-    // contains the base class's name, used for labeling and analysis
-    pub type_descriptor_addr: u32,
-    // The COL for this base class, used in the final label
-    pub complete_object_locator_addr: u32,
-    // The vftable for this base class, used in the final label
-    pub vftable_addr: u32,
-    // Whether this base class is virtually inherited, used for analysis
-    // use InheritanceKind here?
-    pub inheritance_kind: InheritanceKind,
-}
-
-impl Default for RTTIBaseClass {
-    fn default() -> Self {
-        Self {
-            type_descriptor_addr: 0,
-            complete_object_locator_addr: 0,
-            vftable_addr: 0,
-            inheritance_kind: InheritanceKind::Physical(-1),
-        }
-    }
-}
-
-struct RTTIBaseClassCandidate {
-    // contains the name to assign to the COL
-    pub type_descriptor_addr: u32,
-    pub inheritance_kind: InheritanceKind,
 }
 
 // A class that uses RTTI
-#[derive(Clone, Default)]
 struct RTTIClass {
-    pub name: String, // this class's name
-    // A class using RTTI can only ever have one type descriptor, class hierarchy descriptor, and base class array
-    pub type_descriptor_addr: u32,
-    pub class_hierarchy_descriptor_addr: u32,
-    pub base_class_array_addr: u32,
-    pub base_class_array_len: u32, // for ez reference, preventing a BCA lookup for it
-    // Technically an RTTIClass can have multiple BCDs, depending on how many other classes inherit from it,
-    // but this field will store the BCD for this class itself, sourced from the first entry in the BCA.
-    pub base_class_descriptor_addr: u32,
+    // A class using RTTI can only ever have one type descriptor, class hierarchy descriptor (and by extension, Base Class Array)
+    pub name: String, // this class's name, inferred from the type descriptor
+    pub type_descriptor_addr: u32, // type descriptor addr in the exe
+    // Make this an Option because some RTTIClasses can legit just only have a Type Descriptor and nothing else
+    pub class_hierarchy_descriptor: Option<Rc<ClassHierarchyDescriptor>>,
     // But, it can have multiple base classes, each with their own COL and vftable
-    // this field will be for when everything is properly computed and organized
-    pub base_classes: Vec<RTTIBaseClass>,
-    // this is meant to be loose, for tracking discovered addrs that haven't yet been organized into proper RTTIBaseClasses
-    pub direct_base_class_descriptor_addrs: Vec<u32>,
-    // only need to track COLs, since those have a vftable field anyway
-    pub unresolved_col_addrs: Vec<u32>,
-    pub has_any_virtual_inheritance: bool,
+    pub complete_object_locators: Vec<Rc<CompleteObjectLocator>>,
+    // TODO: add a field for base classes/direct bases when walking the inheritance tree
 }
 
 // RTTI Metadata to be passed between functions.
-#[derive(Default)]
 struct RTTIMetadata {
-    // this will be populated when searching for Type Descriptor entries
-    pub type_info_vtable: Option<RTTIExeInfo>,
-    // key = type descriptor addr, value = the RTTI class
-    pub discovered_classes: BTreeMap<u32, RTTIClass>,
-    // LOOKUP MAPS - quick lookup for RTTI Objects via their address in the exe
-    pub base_class_descriptor_lookup: BTreeMap<u32, BaseClassDescriptor>,
-    pub base_class_array_lookup: BTreeMap<u32, BaseClassArray>,
-    pub class_hierarchy_descriptor_lookup: BTreeMap<u32, ClassHierarchyDescriptor>,
-    pub complete_object_locator_lookup: BTreeMap<u32, CompleteObjectLocator>,
-    pub type_descriptor_lookup: BTreeMap<u32, TypeDescriptor>,
-    pub vftable_lookup: BTreeMap<u32, VFTable>,
+    // the addr of type_info's vftable; this will be populated when searching for Type Descriptor entries
+    pub type_info_vtable: Option<u32>,
+    pub discovered_classes: Vec<Rc<RefCell<RTTIClass>>>,
 }
 
-impl RTTIMetadata {
-    // method to walk inheritance tree for TDs?
-    // methods to get from lookups?
-    fn get_type_descriptor(&self, addr: u32) -> &TypeDescriptor {
-        self.type_descriptor_lookup.get(&addr).unwrap_or_else(|| {
-            unreachable!("Invalid Type Descriptor addr {:08X}", addr);
-        })
-    }
+// what if we had RTTI scanning here instead? before any CFA?
+// you can find Type Descriptors from: .?AU, .?AV, .PAU, .PAV
+// doing it here gives you more control over what size the symbols are
+// doing it in here would also mean no SymbolIndex, since we're not replacing symbols, we're adding them
 
-    // only tracks type descriptors for now, subject to change
-    fn walk_inheritance_tree(
-        &self,
-        // the type descriptor of the main class whose inheritance tree we're trying to walk in the first place
-        main_td: u32,
-        direct_bases: &Vec<u32>,
-        has_primary: bool,
-    ) -> Result<Vec<RTTIBaseClassCandidate>> {
-        // a pool of relevant information to be extracted from our direct bases' base classes
-        let mut candidate_pool: Vec<RTTIBaseClassCandidate> = Vec::new();
-
-        // for each direct base DB, note DB's base classes
-        for (i, bcd_addr) in direct_bases.iter().enumerate() {
-            let bcd =
-                self.base_class_descriptor_lookup.get(bcd_addr).unwrap_or_else(|| unreachable!());
-            let cur_bcd_is_physical = bcd.p_disp == -1;
-            let cur_base_class = self
-                .discovered_classes
-                .get(&bcd.type_descriptor_addr)
-                .unwrap_or_else(|| unreachable!());
-
-            // log::debug!(
-            //     "\tDirect base ({}): {}",
-            //     if cur_bcd_is_physical { "physical" } else { "virtual" },
-            //     cur_base_class.name
-            // );
-
-            // from each base class that DB has, record the base class's name (td), physical vs virtual
-            for base in &cur_base_class.base_classes {
-                let td = base.type_descriptor_addr;
-                // let iter_base_class =
-                //     self.discovered_classes.get(&td).unwrap_or_else(|| unreachable!());
-                let mut is_physical = false;
-                // if base's type descriptor == cur base class's type descriptor,
-                // whether this is physical or virtual will depend on cur_bcd_is_physical
-                if td == cur_base_class.type_descriptor_addr {
-                    is_physical = cur_bcd_is_physical;
-                } else {
-                    is_physical = !matches!(base.inheritance_kind, InheritanceKind::Virtual);
-                }
-
-                // log::debug!(
-                //     "\t\tcontains base class ({}): {}",
-                //     if is_physical { "physical" } else { "virtual" },
-                //     iter_base_class.name
-                // );
-
-                // if there's already a candidate in our pool with the same type descriptor
-                if let Some(existing_candidate) =
-                    candidate_pool.iter_mut().find(|c| c.type_descriptor_addr == td)
-                {
-                    // but, it happens to be virtual, and this one is physical
-                    if matches!(existing_candidate.inheritance_kind, InheritanceKind::Virtual)
-                        && is_physical
-                    {
-                        // swap it out
-                        existing_candidate.inheritance_kind = InheritanceKind::Physical(0);
-                    }
-                }
-                // else, just add it as normal
-                else {
-                    candidate_pool.push(RTTIBaseClassCandidate {
-                        type_descriptor_addr: td,
-                        inheritance_kind: if is_physical {
-                            InheritanceKind::Physical(0)
-                        } else {
-                            InheritanceKind::Virtual
-                        },
-                    });
-                }
-
-                // let mut inheritance_kind: InheritanceKind;
-                // if !is_physical || base.is_virtual {
-                //     inheritance_kind = InheritanceKind::Virtual;
-                // } else {
-                //     // examine the base's COL (if it's not 0) and look at the offset
-                //     // add that to bcd's m_disp
-                //     let col = self
-                //         .complete_object_locator_lookup
-                //         .get(&base.complete_object_locator_addr)
-                //         .unwrap_or_else(|| unreachable!());
-                //     inheritance_kind = InheritanceKind::Physical(col.offset as i32 + bcd.m_disp);
-                // }
-                //
-                // candidate_pool
-                //     .push(RTTIBaseClassCandidate { type_descriptor_addr: td, inheritance_kind })
-            }
-        }
-        if has_primary {
-            // From the first direct physical base, the first physical base that has a COL for it, is the primary base
-            if let Some(index) = candidate_pool.iter().position(|candidate| {
-                matches!(candidate.inheritance_kind, InheritanceKind::Physical(_))
-            }) {
-                let primary = candidate_pool.remove(index);
-                // push it up front, we're gonna make the first entry in our candidate pool the primary
-                candidate_pool.insert(0, primary);
-            }
-            // Or, if there are no direct physical bases, add yourself to the recorded base classes, and make yourself the primary
-            else {
-                candidate_pool.insert(0, RTTIBaseClassCandidate {
-                    type_descriptor_addr: main_td,
-                    inheritance_kind: InheritanceKind::Physical(0),
-                });
-            }
-        }
-
-        // add another pass here? to remove any physical candidates that don't fit for any physical COL (0/X/0)
-
-        for (i, candidate) in candidate_pool.iter().enumerate() {
-            let cand_class = self
-                .discovered_classes
-                .get(&candidate.type_descriptor_addr)
-                .unwrap_or_else(|| unreachable!());
-            if i == 0 && has_primary {
-                log::debug!("\tPrimary candidate: {}", cand_class.name);
-            } else {
-                let phys_str = match candidate.inheritance_kind {
-                    InheritanceKind::Physical(_) => "physical",
-                    InheritanceKind::Virtual => "virtual",
-                };
-                log::debug!("\tCandidate ({}): {}", phys_str, cand_class.name);
-            }
-        }
-
-        Ok(candidate_pool)
-    }
-}
-
-// i had to steal this from LLVM's MicrosoftCXXNameMangler::mangleNumber and mangleBits
-fn encode_num(num: i32) -> String {
-    // <non-negative integer> ::= A@              # when Number == 0
-    //                        ::= <decimal digit> # when 1 <= Number <= 10
-    //                        ::= <hex digit>+ @  # when Number >= 10
-    // <number>               ::= [?] <non-negative integer>
-    let mut ret = String::new();
-    let mut eval = num;
-    if eval < 0 {
-        eval = -eval;
-        ret.push('?');
-    }
-    if eval == 0 {
-        ret.push_str("A@");
-    } else if eval >= 1 && eval <= 10 {
-        ret += &*(eval - 1).to_string();
-    } else {
-        let mut digits = Vec::new();
-        let mut value = eval as u32;
-        while value != 0 {
-            let nibble = (value & 0xF) as u8;
-            digits.push((b'A' + nibble) as char);
-            value >>= 4;
-        }
-        digits.reverse();
-        for ch in digits {
-            ret.push(ch);
-        }
-        ret.push('@');
-    }
-    ret
-}
-
-fn find_rtti_type_descriptors(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<()> {
-    let Some((section_index, section)) = obj.sections.by_name(".data")? else {
-        unreachable!("RTTI being used, but there's no .data section???");
+fn find_all_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<bool> {
+    let Some((_, data_section)) = obj.sections.by_name(".data")? else {
+        unreachable!("No .data section???");
     };
 
-    // find the RTTI type descriptors in .data
-    for (sym_idx, sym) in obj.symbols.for_section(section_index) {
-        // 4 bytes for the type_info vtable, 4 bytes of 0, then the name - will start with ".?AU" for structs or ".?AV" for classes
-        if sym.size < 12 {
-            continue;
-        }
+    // temporary maps to help us when populating/parsing RTTI objects
+    let mut type_descriptor_lookup: BTreeMap<u32, Rc<RefCell<RTTIClass>>> = BTreeMap::new();
 
-        let sym_data = section.symbol_data(sym)?;
-        if &sym_data[8..12] == b".?AU" || &sym_data[8..12] == b".?AV" {
-            let this_vtable_addr = u32::from_be_bytes(sym_data[0..4].try_into()?);
-
+    // first, find the RTTI Type Descriptors in .data
+    // since we aren't using ObjSymbols this time around, search for every instance of .?AU, .?AV, .PAU, .PAV
+    let mut i = 8;
+    let data = &data_section.data;
+    while i < data.len() {
+        let chunk = &data[i..i + 4];
+        if chunk == b".?AU" || chunk == b".?AV" || chunk == b".PAU" || chunk == b".PAV" {
+            let td_addr = data_section.address as u32 + (i - 8) as u32;
+            let this_vtable_addr = u32::from_be_bytes(data[i - 8..i - 4].try_into()?);
             // if we've already set the global type info vtable addr
-            if let Some(global_vtable) = &rtti.type_info_vtable {
+            if let Some(global_vtable_addr) = rtti.type_info_vtable {
                 // check that the one we just read is the same, as there can only be one unique type info vtable addr
                 assert_eq!(
-                    global_vtable.addr, this_vtable_addr,
+                    global_vtable_addr, this_vtable_addr,
                     "type_info::vftable address mismatch!"
                 );
             } else {
                 // else, populate the global vtable addr with this one
-                // need the symbol index of type info's vtable - sym_idx == the symbol of the Type Descriptor
-                if let Some((vtable_sym_idx, _)) = obj
-                    .symbols
-                    .at_section_address(
-                        obj.sections.at_address(this_vtable_addr)?.0,
-                        this_vtable_addr,
-                    )
-                    .next()
-                {
-                    rtti.type_info_vtable =
-                        Some(RTTIExeInfo { symbol_index: vtable_sym_idx, addr: this_vtable_addr });
-                }
+                rtti.type_info_vtable = Some(this_vtable_addr);
             }
-
-            let should_be_zero = u32::from_be_bytes(sym_data[4..8].try_into()?);
+            let should_be_zero = u32::from_be_bytes(data[i - 4..i].try_into()?);
             assert_eq!(
                 should_be_zero, 0,
                 "how on earth is this not zero: type descriptor spare, addr {:08X}",
-                sym.address as u32
+                td_addr
             );
-
             // str from_utf8 doesn't stop at the null terminator
             // why would it? that would make life too easy
             fn cstr_slice_to_str(bytes: &[u8]) -> Result<&str, std::str::Utf8Error> {
                 let end = bytes.iter().position(|&b| b == 0).unwrap_or(bytes.len());
                 std::str::from_utf8(&bytes[..end])
             }
-
             // purposefully skipping the . at the start
-            // additionally, sym_data doesn't always contain the full string,
-            // so we're just gonna pass in ALL the data from this section, starting with the first "?" in the name
-            let type_str = cstr_slice_to_str(&section.data_range(sym.address as u32 + 9, 0)?)?;
+            // additionally, since we don't know how long the full string is,
+            // we're just gonna pass in ALL the data from this section, starting with the first "?" in the name
+            let type_str = cstr_slice_to_str(&data_section.data_range(td_addr + 9, 0)?)?;
 
-            let this_type_desc = TypeDescriptor {
-                exe_info: RTTIExeInfo { symbol_index: sym_idx, addr: sym.address as u32 },
+            let new_rtti_class = RTTIClass {
                 name: type_str.to_string(),
+                type_descriptor_addr: td_addr,
+                class_hierarchy_descriptor: None,
+                complete_object_locators: Vec::new(),
             };
 
-            rtti.type_descriptor_lookup.insert(sym.address as u32, this_type_desc);
+            let rtti_class_ptr = Rc::new(RefCell::new(new_rtti_class));
+            rtti.discovered_classes.push(rtti_class_ptr.clone());
+            type_descriptor_lookup.insert(td_addr, rtti_class_ptr.clone());
 
-            let mut new_rtti_class = RTTIClass::default();
-            new_rtti_class.name = type_str.to_string();
-            new_rtti_class.type_descriptor_addr = sym.address as u32;
-            rtti.discovered_classes.insert(new_rtti_class.type_descriptor_addr, new_rtti_class);
-
-            // log::debug!("Discovered RTTI Type Descriptor entry: {}", type_str);
-        }
-    }
-    Ok(())
-}
-
-fn find_bcds_and_cols(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<()> {
-    let Some((section_index, section)) = obj.sections.by_name(".rdata")? else {
-        unreachable!("RTTI being used, but there's no .rdata section???");
-    };
-
-    // the remaining RTTI structures live in .rdata
-    for (sym_idx, sym) in obj.symbols.for_section(section_index) {
-        // this obviously would not apply to strings
-        // the objects we care about are all at least 16 bytes
-        if sym.name.starts_with("str_") || sym.size < 4 {
-            continue;
-        }
-
-        let sym_data = section.symbol_data(sym)?; // data_range
-        let first_word = u32::from_be_bytes(sym_data[0..4].try_into()?);
-
-        // if the first word is a Type Descriptor address, this is a Base Class Descriptor
-        if let Some(rtti_class) = rtti.discovered_classes.get_mut(&first_word) {
-            // log::debug!("RTTI Base Class Descriptor found at: {:#08X}", sym.address as u32);
-
-            // base class descriptors are 28 bytes / 7 words
-            let base_class_descriptor_data =
-                section.data_range(sym.address as u32, sym.address as u32 + 28)?;
-
-            // check the CHD addr and make sure it's the same
-            // we'll actually parse CHDs/add them to our lookup outside of this loop
-            let chd_addr = u32::from_be_bytes(base_class_descriptor_data[24..28].try_into()?);
-            if rtti_class.class_hierarchy_descriptor_addr != 0 {
-                assert_eq!(
-                    rtti_class.class_hierarchy_descriptor_addr, chd_addr,
-                    "Found different Class Hierarchy Descriptor locations! addr {:08X}",
-                    sym.address as u32
-                );
-            } else {
-                rtti_class.class_hierarchy_descriptor_addr = chd_addr;
-            }
-            let bcd = BaseClassDescriptor {
-                exe_info: RTTIExeInfo { symbol_index: sym_idx, addr: sym.address as u32 },
-                type_descriptor_addr: first_word,
-                num_contained_bases: u32::from_be_bytes(
-                    base_class_descriptor_data[4..8].try_into()?,
-                ),
-                m_disp: i32::from_be_bytes(base_class_descriptor_data[8..12].try_into()?),
-                p_disp: i32::from_be_bytes(base_class_descriptor_data[12..16].try_into()?),
-                v_disp: i32::from_be_bytes(base_class_descriptor_data[16..20].try_into()?),
-                attributes: u32::from_be_bytes(base_class_descriptor_data[20..24].try_into()?),
-                class_hierarchy_descriptor_addr: chd_addr,
-            };
-            rtti.base_class_descriptor_lookup.insert(sym.address as u32, bcd);
-        } else if sym.size >= 16 {
-            // if the 4th word is a Type Descriptor address, this is a Complete Object Locator
-            let fourth_word = u32::from_be_bytes(sym_data[12..16].try_into()?);
-            if let Some(rtti_class) = rtti.discovered_classes.get_mut(&fourth_word) {
-                // log::debug!("RTTI Complete Object Locator found at: {:#08X}", sym.address as u32);
-
-                // complete object locators are 20 bytes / 5 words
-                let complete_object_locator_data =
-                    section.data_range(sym.address as u32, sym.address as u32 + 20)?;
-
-                // check the CHD addr and make sure it's the same
-                // we'll actually parse CHDs/add them to our lookup outside of this loop
-                let chd_addr = u32::from_be_bytes(complete_object_locator_data[16..20].try_into()?);
-                if rtti_class.class_hierarchy_descriptor_addr != 0 {
-                    assert_eq!(
-                        rtti_class.class_hierarchy_descriptor_addr, chd_addr,
-                        "Found different Class Hierarchy Descriptor locations! addr {:08X}",
-                        sym.address as u32
-                    );
-                } else {
-                    rtti_class.class_hierarchy_descriptor_addr = chd_addr;
-                }
-                // create a CompleteObjectLocator and add to the lookup
-                let col = CompleteObjectLocator {
-                    exe_info: RTTIExeInfo { symbol_index: sym_idx, addr: sym.address as u32 },
-                    signature: u32::from_be_bytes(complete_object_locator_data[0..4].try_into()?),
-                    offset: u32::from_be_bytes(complete_object_locator_data[4..8].try_into()?),
-                    cd_offset: u32::from_be_bytes(complete_object_locator_data[8..12].try_into()?),
-                    type_descriptor_addr: fourth_word,
-                    class_hierarchy_descriptor_addr: chd_addr,
-                    // we'll find this later
-                    vftable_addr: 0,
-                };
-                assert_eq!(
-                    col.signature, 0,
-                    "how on earth is this not zero: COL signature, addr {:08X}",
-                    sym.address as u32
-                );
-                rtti_class.unresolved_col_addrs.push(sym.address as u32);
-                rtti.complete_object_locator_lookup.insert(sym.address as u32, col);
-            }
-        }
-    }
-    Ok(())
-}
-
-fn find_chds_and_bcas(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<()> {
-    let Some((section_index, section)) = obj.sections.by_name(".rdata")? else {
-        unreachable!("RTTI being used, but there's no .rdata section???");
-    };
-
-    for cur_rtti_class in &mut rtti.discovered_classes.values_mut() {
-        if cur_rtti_class.class_hierarchy_descriptor_addr != 0 {
-            // get the CHD, and in the process, the addr of the corresponding BCA
-            let Some((chd_sym_idx, chd_sym)) = obj
-                .symbols
-                .at_section_address(section_index, cur_rtti_class.class_hierarchy_descriptor_addr)
-                .next()
-            else {
-                unreachable!(
-                    "CHD addr is not 0 ({:08X}), but despite that, we can't find its symbol in the exe!", cur_rtti_class.class_hierarchy_descriptor_addr
-                );
-            };
-            assert_eq!(chd_sym.address as u32, cur_rtti_class.class_hierarchy_descriptor_addr);
-            // complete object locators are 16 bytes / 4 words
-            let class_hierarchy_descriptor_data = section.data_range(
-                cur_rtti_class.class_hierarchy_descriptor_addr,
-                cur_rtti_class.class_hierarchy_descriptor_addr + 16,
-            )?;
-
-            // create a CHD and add to our lookup
-            let chd = ClassHierarchyDescriptor {
-                exe_info: RTTIExeInfo {
-                    symbol_index: chd_sym_idx,
-                    addr: cur_rtti_class.class_hierarchy_descriptor_addr,
-                },
-                signature: u32::from_be_bytes(class_hierarchy_descriptor_data[0..4].try_into()?),
-                attributes: u32::from_be_bytes(class_hierarchy_descriptor_data[4..8].try_into()?),
-                num_base_classes: u32::from_be_bytes(
-                    class_hierarchy_descriptor_data[8..12].try_into()?,
-                ),
-                base_class_array_addr: u32::from_be_bytes(
-                    class_hierarchy_descriptor_data[12..16].try_into()?,
-                ),
-            };
-            assert_eq!(
-                chd.signature, 0,
-                "how on earth is this not zero: CHD signature, addr {:08X}",
-                chd_sym.address as u32
-            );
-            cur_rtti_class.base_class_array_addr = chd.base_class_array_addr;
-            let num_bca_entries = chd.num_base_classes;
-            rtti.class_hierarchy_descriptor_lookup
-                .insert(cur_rtti_class.class_hierarchy_descriptor_addr, chd);
-
-            // now, this obj should have a BCA set, so let's analyze that
-            assert_ne!(cur_rtti_class.base_class_array_addr, 0);
-            assert_ne!(num_bca_entries, 0);
-
-            let Some((bca_sym_idx, bca_sym)) = obj
-                .symbols
-                .at_section_address(section_index, cur_rtti_class.base_class_array_addr)
-                .next()
-            else {
-                unreachable!(
-                    "BCA addr is not 0 ({:08X}), but despite that, we can't find its symbol in the exe!", cur_rtti_class.base_class_array_addr
-                );
-            };
-            assert_eq!(bca_sym.address as u32, cur_rtti_class.base_class_array_addr);
-            let mut bca_entries = Vec::with_capacity(num_bca_entries as usize);
-            let base_class_array_data = section.data_range(
-                cur_rtti_class.base_class_array_addr,
-                cur_rtti_class.base_class_array_addr + (num_bca_entries * 4),
-            )?;
-            for chunk in base_class_array_data.chunks_exact(4) {
-                bca_entries.push(u32::from_be_bytes(chunk.try_into()?));
-            }
-            assert_eq!(bca_entries.len(), num_bca_entries as usize);
-            let bca = BaseClassArray {
-                exe_info: RTTIExeInfo {
-                    symbol_index: bca_sym_idx,
-                    addr: cur_rtti_class.base_class_array_addr,
-                },
-                base_class_descriptors: bca_entries,
-            };
-            cur_rtti_class.base_class_array_len = bca.base_class_descriptors.len() as u32;
-            rtti.base_class_array_lookup.insert(cur_rtti_class.base_class_array_addr, bca);
-        }
-        // no unreachable!() else case here, because some Type Descriptors legit just don't have other RTTI metadata
-    }
-    Ok(())
-}
-
-fn find_vftables(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<()> {
-    let Some((section_index, section)) = obj.sections.by_name(".rdata")? else {
-        unreachable!("RTTI being used, but there's no .rdata section???");
-    };
-
-    // run through the objects in .rdata again, and check if the previous addr over has a value in complete_object_locator_addresses.
-    // if it does, then we're looking at the corresponding vftable
-    let mut first = true;
-    for (sym_idx, sym) in obj.symbols.for_section(section_index) {
-        // skip the first item, since we're doing a little subtraction
-        if first {
-            first = false;
-            continue;
-        }
-        // this obviously would not apply to strings
-        if sym.name.starts_with("str_") {
-            continue;
-        }
-
-        let maybe_complete_object_locator_address = u32::from_be_bytes(
-            section.data_range((sym.address - 4) as u32, sym.address as u32)?.try_into()?,
-        );
-
-        // log::debug!("Found the vtable for {}! It's at {:08X}", rtti_name, sym.address);
-        let vftable =
-            VFTable { exe_info: RTTIExeInfo { symbol_index: sym_idx, addr: sym.address as u32 } };
-        rtti.vftable_lookup.insert(sym.address as u32, vftable);
-
-        // thanks to ownership we have to COL lookup twice
-        if let Some(col) =
-            rtti.complete_object_locator_lookup.get_mut(&maybe_complete_object_locator_address)
-        {
-            col.vftable_addr = sym.address as u32;
-        }
-    }
-    Ok(())
-}
-
-fn find_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<()> {
-    // first, find the RTTI Type Descriptors
-    find_rtti_type_descriptors(obj, rtti)?;
-    // then a few more sweeps to get the rest
-    // first sweep: get BCDs and COLs in our lookups
-    // our RTTIClasses will have CHD addresses, but they won't be analyzed yet
-    find_bcds_and_cols(obj, rtti)?;
-    // second sweep: with our CHD addresses, create CHDs and BCAs for our lookups
-    find_chds_and_bcas(obj, rtti)?;
-    // last sweep: from the COLs we have, get the vftables
-    find_vftables(obj, rtti)?;
-    Ok(())
-}
-
-fn compute_direct_bases(rtti: &mut RTTIMetadata) -> Result<Vec<u32>> {
-    let mut classes_to_process_by_type_descriptor = Vec::new();
-    // for each RTTIClass, go through the BCA and determine the superclasses from their BCDs
-    for rtti_class in &mut rtti.discovered_classes.values_mut() {
-        classes_to_process_by_type_descriptor.push(rtti_class.type_descriptor_addr);
-        if let Some(bca) = rtti.base_class_array_lookup.get(&rtti_class.base_class_array_addr) {
-            // we skip over the first entry in the BCA, because it's just the BCD for this class
-            rtti_class.base_class_descriptor_addr = bca.base_class_descriptors[0];
-            let mut i = 1;
-            while i < bca.base_class_descriptors.len() {
-                // the BCD evaluated here is a base class of this RTTIClass...
-                let cur_bcd_addr = bca.base_class_descriptors[i];
-                let Some(cur_bcd) = rtti.base_class_descriptor_lookup.get(&cur_bcd_addr) else {
-                    unreachable!(
-                        "BCA at {:08X} has an invalid BCD {:08X}!",
-                        bca.exe_info.addr, cur_bcd_addr
-                    );
-                };
-                // ...so mark down the bcd addr, and then advance i by however many num bases the BCD says there are + 1
-                rtti_class.direct_base_class_descriptor_addrs.push(cur_bcd_addr);
-                i += cur_bcd.num_contained_bases as usize + 1;
-            }
-            // check for ANY sign of virtual inheritance in the tree
-            for cur_bcd_addr in bca.base_class_descriptors.iter() {
-                let Some(cur_bcd) = rtti.base_class_descriptor_lookup.get(&cur_bcd_addr) else {
-                    unreachable!(
-                        "BCA at {:08X} has an invalid BCD {:08X}!",
-                        bca.exe_info.addr, cur_bcd_addr
-                    );
-                };
-                if cur_bcd.attributes & 0x10 != 0 {
-                    rtti_class.has_any_virtual_inheritance = true;
-                    break;
-                }
-            }
-        }
-    }
-    // now, sort the RTTIClasses by smallest number of unresolved vftables
-    // we do this because smaller vftable counts are likely to have less complex inheritance.
-    // also, RTTIClasses with smaller vftable counts will very likely serve as the base classes
-    // for more complexly inherited classes down the line as we progress through the Vec.
-    // within each group of RTTIClasses that have the same number of COLs/vftables,
-    // further sort them by smallest number of BCA entries.
-    classes_to_process_by_type_descriptor.sort_by_key(|td| {
-        let c = rtti.discovered_classes.get(td).unwrap_or_else(|| unreachable!());
-        (c.unresolved_col_addrs.len(), c.base_class_array_len)
-    });
-    Ok(classes_to_process_by_type_descriptor)
-}
-
-fn compute_superclasses(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<()> {
-    let classes_to_process_by_type_descriptor = compute_direct_bases(rtti)?;
-    for td in &classes_to_process_by_type_descriptor {
-        let mut new_rtti_class =
-            rtti.discovered_classes.get(td).unwrap_or_else(|| unreachable!()).clone();
-        // if this RTTIClass doesn't even have a BCA, don't bother with all this
-        if new_rtti_class.base_class_array_addr == 0 {
-            continue;
-        }
-
-        // 0 COLs/vftables - still record base class info anyway
-        if new_rtti_class.unresolved_col_addrs.len() == 0 {
-            for direct_bcd_addr in &new_rtti_class.direct_base_class_descriptor_addrs {
-                let bcd = rtti
-                    .base_class_descriptor_lookup
-                    .get(direct_bcd_addr)
-                    .unwrap_or_else(|| unreachable!());
-                new_rtti_class.base_classes.push(RTTIBaseClass {
-                    type_descriptor_addr: bcd.type_descriptor_addr,
-                    complete_object_locator_addr: 0,
-                    vftable_addr: 0,
-                    inheritance_kind: InheritanceKind::Physical(0),
-                });
-            }
-            *rtti.discovered_classes.get_mut(td).unwrap_or_else(|| unreachable!()) = new_rtti_class;
-        }
-        // 1 COL/vftable = zero virtual inheritance, easiest case to deal with rn
-        else if new_rtti_class.unresolved_col_addrs.len() == 1 {
-            let Some(my_sole_col) =
-                rtti.complete_object_locator_lookup.get(&new_rtti_class.unresolved_col_addrs[0])
-            else {
-                unreachable!(
-                    "RTTI class {} has an invalid COL addr {:08X}!",
-                    new_rtti_class.name, new_rtti_class.unresolved_col_addrs[0]
-                );
-            };
-            new_rtti_class.base_classes.push(RTTIBaseClass {
-                // for 1 COL/vftable, it belongs to us - so use our TD
-                type_descriptor_addr: new_rtti_class.type_descriptor_addr,
-                complete_object_locator_addr: my_sole_col.exe_info.addr,
-                vftable_addr: my_sole_col.vftable_addr,
-                inheritance_kind: InheritanceKind::Physical(0),
-            });
-            new_rtti_class.unresolved_col_addrs.clear();
-            *rtti.discovered_classes.get_mut(td).unwrap_or_else(|| unreachable!()) = new_rtti_class;
-        }
-        // arbitrary len limit, just lowering the scope
-        else if new_rtti_class.unresolved_col_addrs.len() <= 3 {
-            // this branch and onward (when unresolved_col_addrs.len > 1)
-            // will require walking up the inheritance tree to get the COL/vftable base class names
-            log::debug!(
-                "RTTI Class with {} COL/vftables {} has {} direct bases!",
-                new_rtti_class.unresolved_col_addrs.len(),
-                new_rtti_class.name,
-                new_rtti_class.direct_base_class_descriptor_addrs.len()
-            );
-
-            // If there's a COL with 0,0,0, a primary COL exists
-            // if false, we don't assign a primary candidate in walk inheritance tree
-            let has_primary_col = new_rtti_class.unresolved_col_addrs.iter().any(|col_addr| {
-                let col = rtti
-                    .complete_object_locator_lookup
-                    .get(col_addr)
-                    .unwrap_or_else(|| unreachable!());
-                col.signature == 0 && col.offset == 0 && col.cd_offset == 0
-            });
-
-            let base_class_candidate_pool = rtti.walk_inheritance_tree(
-                new_rtti_class.type_descriptor_addr,
-                &new_rtti_class.direct_base_class_descriptor_addrs,
-                has_primary_col,
-            )?;
-
-            if base_class_candidate_pool.len() != new_rtti_class.unresolved_col_addrs.len() {
-                log::warn!("RTTIClass {} inheritance tree was not correctly processed, skipping further analysis...", new_rtti_class.name);
-                continue;
-            }
-
-            for col_addr in new_rtti_class.unresolved_col_addrs.iter() {
-                let col = rtti
-                    .complete_object_locator_lookup
-                    .get(col_addr)
-                    .unwrap_or_else(|| unreachable!());
-                log::debug!("\tCOL: {}, {}, {}", col.signature, col.offset, col.cd_offset);
-            }
-
-            for candidate in base_class_candidate_pool.iter() {
-                new_rtti_class.base_classes.push(RTTIBaseClass {
-                    type_descriptor_addr: candidate.type_descriptor_addr,
-                    complete_object_locator_addr: 0,
-                    vftable_addr: 0,
-                    inheritance_kind: candidate.inheritance_kind.clone(),
-                })
-            }
-            *rtti.discovered_classes.get_mut(td).unwrap_or_else(|| unreachable!()) = new_rtti_class;
-
-            // match candidates in our pool to COL/vftables
-            // the one whose offset is 0, that's either this class or a direct base
-        }
-
-        // else {
-        //     log::debug!(
-        //         "RTTI Class {} has {} direct bases and {} COL/vftable pairs to analyze!",
-        //         rtti_class.name,
-        //         rtti_class.direct_base_class_descriptor_addrs.len(),
-        //         rtti_class.unresolved_col_addrs.len()
-        //     );
-        // }
-    }
-
-    Ok(())
-}
-
-fn apply_rtti_symbols(obj: &mut ObjInfo, rtti: &RTTIMetadata) -> Result<()> {
-    // type_info's vftable
-    if let Some(global_vtable_addr) = &rtti.type_info_vtable {
-        let mut new_sym = obj.symbols[global_vtable_addr.symbol_index].clone();
-        new_sym.name = "??_7type_info@@6B@".to_string();
-        obj.symbols.replace(global_vtable_addr.symbol_index, new_sym)?;
-    } else {
-        unreachable!("So you have RTTI, but no global type info vtable addr?");
-    }
-    // RTTI Base Class Descriptors
-    for (_, bcd) in &rtti.base_class_descriptor_lookup {
-        if let Some(rtti_obj) = rtti.discovered_classes.get(&bcd.type_descriptor_addr) {
-            let mut new_sym = obj.symbols[bcd.exe_info.symbol_index].clone();
-            new_sym.name = format!(
-                "??_R1{}{}{}{}{}8",
-                encode_num(bcd.m_disp),
-                encode_num(bcd.p_disp),
-                encode_num(bcd.v_disp),
-                encode_num(bcd.attributes as i32),
-                rtti_obj.name[3..].to_string()
-            );
-            // TODO: if a symbol exists between this addr, and this addr + 28, wipe it, because that space will go to this symbol
-            // new_sym.size = 28;
-            // new_sym.size_known = true;
-            obj.symbols.replace(bcd.exe_info.symbol_index, new_sym)?;
+            log::debug!("Discovered RTTI Type Descriptor entry at {:08X}: {}", td_addr, type_str);
+            i += type_str.len().next_multiple_of(4);
         } else {
-            unreachable!(
-                "Base Class Array at {:08X} has invalid Type Descriptor addr {:08X}",
-                bcd.exe_info.addr, bcd.type_descriptor_addr
-            );
+            i += 4;
         }
     }
-    // iterate across our RTTIClasses to get TDs, CHDs, and BCAs
-    for (td_addr, rtti_obj) in &rtti.discovered_classes {
-        assert_eq!(td_addr, &rtti_obj.type_descriptor_addr);
-        {
-            let td = rtti.get_type_descriptor(rtti_obj.type_descriptor_addr);
-            let mut new_sym = obj.symbols[td.exe_info.symbol_index].clone();
-            // example:
-            // Type Descriptor class name (. omitted): ?AVFilePath@@
-            // Type Descriptor full symbol: ??_R0?AVFilePath@@@8
-            new_sym.name = format!("??_R0{}@8", rtti_obj.name);
-            // edit the descriptor's size to only be the vtable addr, zero word, and the string length
-            new_sym.size = 8 + rtti_obj.name.len() as u64;
-            // shoutout 4 byte alignment
-            new_sym.size = new_sym.size.next_multiple_of(4);
-            obj.symbols.replace(td.exe_info.symbol_index, new_sym)?;
-        }
-        if rtti_obj.class_hierarchy_descriptor_addr != 0 {
-            if let Some(chd) = rtti
-                .class_hierarchy_descriptor_lookup
-                .get(&rtti_obj.class_hierarchy_descriptor_addr)
-            {
-                let mut new_sym = obj.symbols[chd.exe_info.symbol_index].clone();
-                // example:
-                // Type Descriptor class name (. omitted): ?AVFilePath@@
-                // Class Hierarchy Descriptor full symbol: ??_R3FilePath@@8
-                new_sym.name = format!("??_R3{}8", rtti_obj.name[3..].to_string());
-                obj.symbols.replace(chd.exe_info.symbol_index, new_sym)?;
-            } else {
-                unreachable!(
-                    "RTTI Class {} has invalid Class Hierarchy Descriptor addr {:08X}",
-                    rtti_obj.name, rtti_obj.class_hierarchy_descriptor_addr
-                );
-            }
-        }
-        if rtti_obj.base_class_array_addr != 0 {
-            if let Some(bca) = rtti.base_class_array_lookup.get(&rtti_obj.base_class_array_addr) {
-                let mut new_sym = obj.symbols[bca.exe_info.symbol_index].clone();
-                // example:
-                // Type Descriptor class name (. omitted): ?AVFilePath@@
-                // Class Hierarchy Descriptor full symbol: ??_R2FilePath@@8
-                new_sym.name = format!("??_R2{}8", rtti_obj.name[3..].to_string());
-                obj.symbols.replace(bca.exe_info.symbol_index, new_sym)?;
-            } else {
-                unreachable!(
-                    "RTTI Class {} has invalid Base Class Array addr {:08X}",
-                    rtti_obj.name, rtti_obj.base_class_array_addr
-                );
-            }
-        }
-        // label single COLs and vftables
-        if rtti_obj.base_classes.len() == 1 {
-            let Some(col) = rtti
-                .complete_object_locator_lookup
-                .get(&rtti_obj.base_classes[0].complete_object_locator_addr)
-            else {
-                unreachable!(
-                    "RTTI Class {} has invalid Complete Object Locator addr {:08X}",
-                    rtti_obj.name, rtti_obj.base_classes[0].complete_object_locator_addr
-                );
-            };
-            let mut new_col_sym = obj.symbols[col.exe_info.symbol_index].clone();
-            new_col_sym.name = format!("??_R4{}6B@", rtti_obj.name[3..].to_string());
-            obj.symbols.replace(col.exe_info.symbol_index, new_col_sym)?;
 
-            let Some(vftable) = rtti.vftable_lookup.get(&rtti_obj.base_classes[0].vftable_addr)
-            else {
-                unreachable!(
-                    "RTTI Class {} has invalid vftable addr {:08X}",
-                    rtti_obj.name, rtti_obj.base_classes[0].vftable_addr
-                );
-            };
-
-            let mut new_vftable_sym = obj.symbols[vftable.exe_info.symbol_index].clone();
-            new_vftable_sym.name = format!("??_7{}6B@", rtti_obj.name[3..].to_string());
-            obj.symbols.replace(vftable.exe_info.symbol_index, new_vftable_sym)?;
-        }
-        // TODO: iterate through RTTIClass's base_classes field for multiple COLs/vftables
+    // quick check - if there were 0 Type Descriptors found, RTTI isn't supported, bail early
+    if type_descriptor_lookup.is_empty() {
+        return Ok(false);
     }
-    Ok(())
+
+    // find: COLs (BCDs can't be found reliably)
+    // if we spot a COL, should we go recursively down the graph, creating structs?
+    // so from the COL, step to the CHD, then the BCA, then each of its BCDs?
+
+    Ok(true)
 }
 
-pub fn detect_rtti(obj: &mut ObjInfo) -> Result<()> {
-    if !obj.rtti {
-        log::debug!("This object does not use RTTI, skipping");
-        return Ok(());
+// fn find_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<bool> {
+//     // first, find the RTTI Type Descriptors
+//     find_rtti_type_descriptors(obj, rtti)?;
+//     // quick check - if there were 0 Type Descriptors found, RTTI isn't supported, bail early
+//     if rtti.type_descriptor_lookup.is_empty() {
+//         return Ok(false);
+//     }
+//     // then a few more sweeps to get the rest
+//     // first sweep: get BCDs and COLs in our lookups
+//     // our RTTIClasses will have CHD addresses, but they won't be analyzed yet
+//     find_bcds_and_cols(obj, rtti)?;
+//     // // second sweep: with our CHD addresses, create CHDs and BCAs for our lookups
+//     // find_chds_and_bcas(obj, rtti)?;
+//     // // last sweep: from the COLs we have, get the vftables
+//     // find_vftables(obj, rtti)?;
+//     Ok(true)
+// }
+
+pub struct FindRTTIObjectsXbox {}
+
+impl AnalysisPass for FindRTTIObjectsXbox {
+    fn execute(state: &mut AnalyzerState, obj: &ObjInfo) -> Result<()> {
+        let mut rtti_metadata = RTTIMetadata { type_info_vtable: None, discovered_classes: vec![] };
+
+        log::info!("Hello from FindRTTIObjectsXbox");
+
+        // try to find Type Descriptors
+        // if you found none, that would mean there's no RTTI, so quit early
+        // else, do everything you've already implemented in rtti.rs
+
+        // find all the RTTI structs you can
+        if !find_all_rtti_structs(obj, &mut rtti_metadata)? {
+            return Ok(());
+        }
+
+        // we'll mainly be editing state.known_symbols
+        Ok(())
     }
-
-    // TODO:
-    // this should also detect and label __RTtypeid and __RTDynamicCast
-    // fix __RTtypeid and __RTDynamicCast so there's no dangling fn's
-    // "Bad dynamic_cast!" would mean dynamic cast exists
-    // "Attempted a typeid of NULL pointer!" would mean typeid exists
-
-    let mut rtti_metadata = RTTIMetadata::default();
-
-    // find all the RTTI structs you can
-    find_rtti_structs(obj, &mut rtti_metadata)?;
-    // analyze for superclass info
-    compute_superclasses(obj, &mut rtti_metadata)?;
-    // apply the symbols to the exe
-    apply_rtti_symbols(obj, &rtti_metadata)?;
-
-    Ok(())
 }

--- a/src/analysis/rtti.rs
+++ b/src/analysis/rtti.rs
@@ -8,13 +8,16 @@ use anyhow::Result;
 use memchr::memmem;
 
 use crate::{
-    analysis::{cfa::AnalyzerState, pass::AnalysisPass},
-    obj::ObjInfo,
+    analysis::{
+        cfa::{AnalyzerState, FunctionInfo, SectionAddress},
+        pass::AnalysisPass,
+    },
+    obj::{ObjInfo, ObjSymbol, ObjSymbolFlagSet, ObjSymbolFlags},
+    util::msvc::encode_num,
 };
 
 // An RTTI Base Class Descriptor Object.
 struct BaseClassDescriptor {
-    pub addr: u32,                // the address of this in the exe
     pub num_contained_bases: u32, // number of nested classes following in the Base Class Array
     pub m_disp: i32,              // member displacement
     pub p_disp: i32,              // vbtable displacement
@@ -28,8 +31,7 @@ struct BaseClassDescriptor {
 
 // An RTTI Class Hierarchy Descriptor object. Also contains Base Class Array information.
 struct ClassHierarchyDescriptor {
-    pub addr: u32,                  // the address of this in the exe
-    pub signature: u32,             // always 0
+    pub signature: u32,                                       // always 0
     pub attributes: u32, // bit 0 set = multiple inheritance, bit 1 set = virtual inheritance
     pub num_base_classes: u32, // number of entries in the Base Class Array
     pub base_class_array_addr: u32, // BCA addr in the exe
@@ -55,7 +57,6 @@ struct CompleteObjectLocator {
 struct RTTIClass {
     // A class using RTTI can only ever have one type descriptor, class hierarchy descriptor (and by extension, Base Class Array)
     pub name: String, // this class's name, inferred from the type descriptor
-    pub type_descriptor_addr: u32, // type descriptor addr in the exe
     // Make this an Option because some RTTIClasses can legit just only have a Type Descriptor and nothing else
     pub class_hierarchy_descriptor: Option<ClassHierarchyDescriptor>,
     // But, it can have multiple base classes, each with their own COL and vftable
@@ -65,8 +66,6 @@ struct RTTIClass {
 
 // RTTI Metadata to be passed between functions.
 struct RTTIMetadata {
-    // the addr of type_info's vftable; this will be populated when searching for Type Descriptor entries
-    pub type_info_vtable: Option<u32>,
     pub discovered_classes: Vec<Rc<RefCell<RTTIClass>>>,
 }
 
@@ -75,10 +74,17 @@ struct RTTIMetadata {
 // doing it here gives you more control over what size the symbols are
 // doing it in here would also mean no SymbolIndex, since we're not replacing symbols, we're adding them
 
-fn find_all_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<bool> {
-    let Some((_, data_section)) = obj.sections.by_name(".data")? else {
-        unreachable!("No .data section???");
-    };
+// Parse our ObjInfo for all the RTTI structures we can find.
+// Add labels for RTTI structures as we find them (eager approach), except for COLs, as we'll be analyzing them specially later.
+fn find_all_rtti_structs(
+    state: &mut AnalyzerState,
+    obj: &ObjInfo,
+    rtti: &mut RTTIMetadata,
+) -> Result<bool> {
+    let (data_sec_idx, data_section) = obj.sections.by_name(".data")?.expect("No .data section!");
+
+    // we'll find this as we search for Type Descriptor entries
+    let mut type_info_vtable: Option<u32> = None;
 
     // temporary maps to help us when populating/parsing RTTI objects
     let mut classes_by_type_descriptor_exe_addr: BTreeMap<u32, Rc<RefCell<RTTIClass>>> =
@@ -95,7 +101,7 @@ fn find_all_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<bool>
             let td_addr = data_section.address as u32 + (i - 8) as u32;
             let this_vtable_addr = u32::from_be_bytes(data[i - 8..i - 4].try_into()?);
             // if we've already set the global type info vtable addr
-            if let Some(global_vtable_addr) = rtti.type_info_vtable {
+            if let Some(global_vtable_addr) = type_info_vtable {
                 // check that the one we just read is the same, as there can only be one unique type info vtable addr
                 assert_eq!(
                     global_vtable_addr, this_vtable_addr,
@@ -103,7 +109,7 @@ fn find_all_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<bool>
                 );
             } else {
                 // else, populate the global vtable addr with this one
-                rtti.type_info_vtable = Some(this_vtable_addr);
+                type_info_vtable = Some(this_vtable_addr);
             }
             let should_be_zero = u32::from_be_bytes(data[i - 4..i].try_into()?);
             assert_eq!(
@@ -124,7 +130,6 @@ fn find_all_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<bool>
 
             let new_rtti_class = RTTIClass {
                 name: type_str.to_string(),
-                type_descriptor_addr: td_addr,
                 class_hierarchy_descriptor: None,
                 complete_object_locators: Vec::new(),
             };
@@ -134,6 +139,24 @@ fn find_all_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<bool>
             classes_by_type_descriptor_exe_addr.insert(td_addr, rtti_class_ptr.clone());
 
             // log::debug!("Discovered RTTI Type Descriptor entry at {:08X}: {}", td_addr, type_str);
+
+            state
+                .known_symbols
+                .entry(SectionAddress::new(data_sec_idx, td_addr))
+                .or_default()
+                .push(ObjSymbol {
+                    // example:
+                    // Type Descriptor class name (. omitted): ?AVFilePath@@
+                    // Type Descriptor full symbol: ??_R0?AVFilePath@@@8
+                    name: format!("??_R0{}@8", type_str),
+                    address: td_addr as u64,
+                    section: Some(data_sec_idx),
+                    size: (type_str.len() + 8).next_multiple_of(4) as u64,
+                    size_known: true,
+                    flags: ObjSymbolFlagSet(ObjSymbolFlags::Global.into()),
+                    ..Default::default()
+                });
+
             i += type_str.len().next_multiple_of(4);
         } else {
             i += 4;
@@ -146,14 +169,25 @@ fn find_all_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<bool>
     }
 
     // the remaining RTTI structures live in .rdata
-    let Some((_, rdata_section)) = obj.sections.by_name(".rdata")? else {
-        unreachable!("No .rdata section???");
-    };
+    let (rdata_sec_idx, rdata_section) =
+        obj.sections.by_name(".rdata")?.expect("No .rdata section!");
+    // for parsing vftables
+    let (text_sec_idx, text_section) = obj.sections.by_name(".text")?.expect("No .text section!");
 
-    // for calculating vftable sizes
-    let Some((_, text_section)) = obj.sections.by_name(".text")? else {
-        unreachable!("No .text section???");
-    };
+    // add the type_info vftable here
+    let vftable_addr =
+        type_info_vtable.expect("So there's RTTI, but no global type info vtable addr?");
+    state.known_symbols.entry(SectionAddress::new(rdata_sec_idx, vftable_addr)).or_default().push(
+        ObjSymbol {
+            name: "??_7type_info@@6B@".to_string(),
+            address: vftable_addr as u64,
+            section: Some(rdata_sec_idx),
+            size: 4,
+            size_known: true,
+            flags: ObjSymbolFlagSet(ObjSymbolFlags::Global.into()),
+            ..Default::default()
+        },
+    );
 
     // now, search for COLs after the TDs (BCDs can't be found reliably, they can conflict with catchables)
     let mut i = 0;
@@ -213,6 +247,11 @@ fn find_all_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<bool>
                             && cur_vftable_entry
                                 < text_section.address as u32 + text_section.size as u32
                         {
+                            // add this to our known function addrs
+                            state.functions.insert(
+                                SectionAddress::new(text_sec_idx, cur_vftable_entry),
+                                FunctionInfo { analyzed: false, end: None, slices: None },
+                            );
                             num_vftable_entries += 1;
                         } else {
                             break;
@@ -267,7 +306,6 @@ fn find_all_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<bool>
         let chd_data_idx = chd_exe_addr - rdata_section.address as u32;
         let chd_data = &rdata_section.data[chd_data_idx as usize..chd_data_idx as usize + 16];
         let mut chd = ClassHierarchyDescriptor {
-            addr: chd_exe_addr,
             signature: u32::from_be_bytes(chd_data[0..4].try_into()?),
             attributes: u32::from_be_bytes(chd_data[4..8].try_into()?),
             num_base_classes: u32::from_be_bytes(chd_data[8..12].try_into()?),
@@ -279,6 +317,25 @@ fn find_all_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<bool>
             "how on earth is this not zero: CHD signature, addr {:08X}",
             chd_exe_addr
         );
+
+        // label the CHD here
+        state
+            .known_symbols
+            .entry(SectionAddress::new(rdata_sec_idx, chd_exe_addr))
+            .or_default()
+            .push(ObjSymbol {
+                // example:
+                // Type Descriptor class name (. omitted): ?AVFilePath@@
+                // Class Hierarchy Descriptor full symbol: ??_R3FilePath@@8
+                name: format!("??_R3{}8", the_rtti_class.borrow().name[3..].to_string()),
+                address: chd_exe_addr as u64,
+                section: Some(rdata_sec_idx),
+                size: 16,
+                size_known: true,
+                flags: ObjSymbolFlagSet(ObjSymbolFlags::Global.into()),
+                ..Default::default()
+            });
+
         // if the recorded BCA addr is not within .rdata, something has gone horribly wrong
         assert!(
             rdata_section.address as u32 <= chd.base_class_array_addr
@@ -287,6 +344,26 @@ fn find_all_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<bool>
             "Bad BCA addr {:08X}!",
             chd.base_class_array_addr
         );
+
+        // label the BCA here
+        state
+            .known_symbols
+            .entry(SectionAddress::new(rdata_sec_idx, chd.base_class_array_addr))
+            .or_default()
+            .push(ObjSymbol {
+                // example:
+                // Type Descriptor class name (. omitted): ?AVFilePath@@
+                // Class Hierarchy Descriptor full symbol: ??_R2FilePath@@8
+                name: format!("??_R2{}8", the_rtti_class.borrow().name[3..].to_string()),
+                address: chd.base_class_array_addr as u64,
+                section: Some(rdata_sec_idx),
+                // there's a null word after the last BCD entry, hence the +1
+                size: ((chd.num_base_classes + 1) * 4) as u64,
+                size_known: true,
+                flags: ObjSymbolFlagSet(ObjSymbolFlags::Global.into()),
+                ..Default::default()
+            });
+
         // parse the BCA and BCDs as well, since the CHD will own the BCA
         let bca_data_idx = chd.base_class_array_addr - rdata_section.address as u32;
         let bca_data = &rdata_section.data
@@ -306,7 +383,6 @@ fn find_all_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<bool>
                         panic!("Bad Type Descriptor addr {:08X}!", td_addr);
                     };
                     let bcd_ptr = Rc::new(BaseClassDescriptor {
-                        addr: cur_bcd_addr,
                         num_contained_bases: u32::from_be_bytes(bcd_data[4..8].try_into()?),
                         m_disp: i32::from_be_bytes(bcd_data[8..12].try_into()?),
                         p_disp: i32::from_be_bytes(bcd_data[12..16].try_into()?),
@@ -314,6 +390,27 @@ fn find_all_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<bool>
                         attributes: u32::from_be_bytes(bcd_data[20..24].try_into()?),
                         owner: Rc::downgrade(&class_for_bcd),
                     });
+                    // label the BCD here
+                    state
+                        .known_symbols
+                        .entry(SectionAddress::new(rdata_sec_idx, cur_bcd_addr))
+                        .or_default()
+                        .push(ObjSymbol {
+                            name: format!(
+                                "??_R1{}{}{}{}{}8",
+                                encode_num(bcd_ptr.m_disp),
+                                encode_num(bcd_ptr.p_disp),
+                                encode_num(bcd_ptr.v_disp),
+                                encode_num(bcd_ptr.attributes as i32),
+                                class_for_bcd.borrow().name[3..].to_string()
+                            ),
+                            address: cur_bcd_addr as u64,
+                            section: Some(rdata_sec_idx),
+                            size: 28,
+                            size_known: true,
+                            flags: ObjSymbolFlagSet(ObjSymbolFlags::Global.into()),
+                            ..Default::default()
+                        });
                     entry.insert(bcd_ptr.clone());
                     bcd_ptr
                 }
@@ -335,20 +432,19 @@ pub struct FindRTTIObjectsXbox {}
 
 impl AnalysisPass for FindRTTIObjectsXbox {
     fn execute(state: &mut AnalyzerState, obj: &ObjInfo) -> Result<()> {
-        let mut rtti_metadata = RTTIMetadata { type_info_vtable: None, discovered_classes: vec![] };
+        let mut rtti_metadata = RTTIMetadata { discovered_classes: vec![] };
 
         log::info!("Hello from FindRTTIObjectsXbox");
 
-        // try to find Type Descriptors
-        // if you found none, that would mean there's no RTTI, so quit early
-        // else, do everything you've already implemented in rtti.rs
-
         // find all the RTTI structs you can
-        if !find_all_rtti_structs(obj, &mut rtti_metadata)? {
+        if !find_all_rtti_structs(state, obj, &mut rtti_metadata)? {
             return Ok(());
         }
 
-        // we'll mainly be editing state.known_symbols
+        // if we've reached this point, we have a full set of RTTI objects and their relationships
+        // and everything except for COLs and vftables have been labeled
+        // so, compute superclass information to get the remaining context needed to label those
+
         Ok(())
     }
 }

--- a/src/analysis/rtti.rs
+++ b/src/analysis/rtti.rs
@@ -1,10 +1,11 @@
 use std::{
     cell::RefCell,
-    collections::BTreeMap,
+    collections::{btree_map::Entry, BTreeMap},
     rc::{Rc, Weak},
 };
 
 use anyhow::Result;
+use memchr::memmem;
 
 use crate::{
     analysis::{cfa::AnalyzerState, pass::AnalysisPass},
@@ -13,14 +14,16 @@ use crate::{
 
 // An RTTI Base Class Descriptor Object.
 struct BaseClassDescriptor {
-    pub addr: u32,                        // the address of this in the exe
-    pub type_descriptor: Weak<RTTIClass>, // type descriptor of the class
+    pub addr: u32,                // the address of this in the exe
     pub num_contained_bases: u32, // number of nested classes following in the Base Class Array
     pub m_disp: i32,              // member displacement
     pub p_disp: i32,              // vbtable displacement
     pub v_disp: i32,              // displacement inside vbtable
-    pub attributes: u32, // flags: 0x40 bit means has Class Hierarchy Descriptor, 0x10 bit means base class is virtually inherited
-    pub class_hierarchy_descriptor: Weak<ClassHierarchyDescriptor>,
+    // flags: 0x40 bit means has Class Hierarchy Descriptor, 0x10 bit means base class is virtually inherited
+    pub attributes: u32,
+    // NOTE: The RTTIClass associated with a BCD's TypeDescriptor and ClassHierarchyDescriptor entries will always be the same on Xbox 360,
+    // so we can condense those into one single owner field.
+    pub owner: Weak<RefCell<RTTIClass>>,
 }
 
 // An RTTI Class Hierarchy Descriptor object. Also contains Base Class Array information.
@@ -30,7 +33,7 @@ struct ClassHierarchyDescriptor {
     pub attributes: u32, // bit 0 set = multiple inheritance, bit 1 set = virtual inheritance
     pub num_base_classes: u32, // number of entries in the Base Class Array
     pub base_class_array_addr: u32, // BCA addr in the exe
-    pub base_class_descriptors: Vec<Rc<BaseClassDescriptor>>, // the addresses of the BCDs that make up this Base Class Array
+    pub base_class_descriptors: Vec<Rc<BaseClassDescriptor>>, // the BCDs that make up the Base Class Array
 }
 
 // An RTTI Complete Object Locator.
@@ -39,8 +42,9 @@ struct CompleteObjectLocator {
     pub signature: u32, // always 0
     pub offset: u32,    // offset of this vtable in complete class (from top)
     pub cd_offset: u32, // offset of constructor displacement
-    pub type_descriptor: Weak<RTTIClass>,
-    pub class_hierarchy_descriptor: Weak<ClassHierarchyDescriptor>,
+    // NOTE: The RTTIClass associated with a COL's TypeDescriptor and ClassHierarchyDescriptor entries will always be the same on Xbox 360,
+    // so we can condense those into one single owner field.
+    pub owner: Weak<RefCell<RTTIClass>>,
     // The address of the vftable associated with this COL
     pub vftable_addr: u32,
 }
@@ -53,7 +57,7 @@ struct RTTIClass {
     // Make this an Option because some RTTIClasses can legit just only have a Type Descriptor and nothing else
     pub class_hierarchy_descriptor: Option<Rc<ClassHierarchyDescriptor>>,
     // But, it can have multiple base classes, each with their own COL and vftable
-    pub complete_object_locators: Vec<Rc<CompleteObjectLocator>>,
+    pub complete_object_locators: Vec<CompleteObjectLocator>,
     // TODO: add a field for base classes/direct bases when walking the inheritance tree
 }
 
@@ -75,7 +79,9 @@ fn find_all_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<bool>
     };
 
     // temporary maps to help us when populating/parsing RTTI objects
-    let mut type_descriptor_lookup: BTreeMap<u32, Rc<RefCell<RTTIClass>>> = BTreeMap::new();
+    let mut classes_by_type_descriptor_exe_addr: BTreeMap<u32, Rc<RefCell<RTTIClass>>> =
+        BTreeMap::new();
+    let mut classes_by_chd_exe_addr: BTreeMap<u32, Rc<RefCell<RTTIClass>>> = BTreeMap::new();
 
     // first, find the RTTI Type Descriptors in .data
     // since we aren't using ObjSymbols this time around, search for every instance of .?AU, .?AV, .PAU, .PAV
@@ -123,9 +129,9 @@ fn find_all_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<bool>
 
             let rtti_class_ptr = Rc::new(RefCell::new(new_rtti_class));
             rtti.discovered_classes.push(rtti_class_ptr.clone());
-            type_descriptor_lookup.insert(td_addr, rtti_class_ptr.clone());
+            classes_by_type_descriptor_exe_addr.insert(td_addr, rtti_class_ptr.clone());
 
-            log::debug!("Discovered RTTI Type Descriptor entry at {:08X}: {}", td_addr, type_str);
+            // log::debug!("Discovered RTTI Type Descriptor entry at {:08X}: {}", td_addr, type_str);
             i += type_str.len().next_multiple_of(4);
         } else {
             i += 4;
@@ -133,34 +139,104 @@ fn find_all_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<bool>
     }
 
     // quick check - if there were 0 Type Descriptors found, RTTI isn't supported, bail early
-    if type_descriptor_lookup.is_empty() {
+    if classes_by_type_descriptor_exe_addr.is_empty() {
         return Ok(false);
     }
 
-    // find: COLs (BCDs can't be found reliably)
-    // if we spot a COL, should we go recursively down the graph, creating structs?
-    // so from the COL, step to the CHD, then the BCA, then each of its BCDs?
+    // the remaining RTTI structures live in .rdata
+    let Some((_, rdata_section)) = obj.sections.by_name(".rdata")? else {
+        unreachable!("No .rdata section???");
+    };
+
+    // now, search for COLs after the TDs (BCDs can't be found reliably, they can conflict with catchables)
+    let mut i = 0;
+    let data = &rdata_section.data;
+    while i < data.len() {
+        let cur_word = u32::from_be_bytes(data[i..i + 4].try_into()?);
+        // if cur word is a key that exists in type_descriptor_lookup
+        if let Some(rtti_class) = classes_by_type_descriptor_exe_addr.get(&cur_word) {
+            // check the next word over
+            let next_word = u32::from_be_bytes(data[i + 4..i + 8].try_into()?);
+            // if it's a valid address in rdata, it means we're looking at a Complete Object Locator.
+            if rdata_section.address as u32 <= next_word
+                && next_word < rdata_section.address as u32 + rdata_section.size as u32
+            {
+                let col_start_addr = rdata_section.address as u32 + (i - 12) as u32;
+                // log::debug!(
+                //     "Discovered RTTI Complete Object Locator entry at {:08X}!",
+                //     col_start_addr
+                // );
+
+                // because we're using Rc's, it means we gotta get all our fields initialized before we apply the Rc<> part.
+                // so, when parsing a COL, take note of the ClassHierarchyDescriptor addr (add it in another lookup map)
+                // and then get the vftable addr right then and there, using the COL's addr
+
+                // next_word == the COL's CHD address
+                match classes_by_chd_exe_addr.entry(next_word) {
+                    Entry::Vacant(entry) => {
+                        entry.insert(rtti_class.clone());
+                    }
+                    Entry::Occupied(entry) => {
+                        assert!(
+                            Rc::ptr_eq(entry.get(), &rtti_class),
+                            "CHD {:08X} already associated with a different RTTIClass {}!",
+                            next_word,
+                            rtti_class.borrow().name,
+                        );
+                    }
+                }
+
+                // search for col_start_addr in .rdata
+                let col_start_addr_bytes = col_start_addr.to_be_bytes();
+                if let Some(vftable_idx) = memmem::find(data, &col_start_addr_bytes) {
+                    // the vftable is the next addr over from the COL, hence the +4
+                    let vftable_addr = rdata_section.address as u32 + vftable_idx as u32 + 4;
+
+                    // TODO: calculate vftable length here? add a field for it to CompleteObjectLocator?
+
+                    // log::debug!(
+                    //     "VFTable for COL at {:08X} found! It's at {:08X}",
+                    //     col_start_addr,
+                    //     vftable_addr
+                    // );
+
+                    let col = CompleteObjectLocator {
+                        addr: col_start_addr,
+                        signature: u32::from_be_bytes(data[i - 12..i - 8].try_into()?),
+                        offset: u32::from_be_bytes(data[i - 8..i - 4].try_into()?),
+                        cd_offset: u32::from_be_bytes(data[i - 4..i].try_into()?),
+                        owner: Rc::downgrade(&rtti_class),
+                        vftable_addr,
+                    };
+                    assert_eq!(
+                        col.signature, 0,
+                        "how on earth is this not zero: COL signature, addr {:08X}",
+                        col_start_addr
+                    );
+                    rtti_class.borrow_mut().complete_object_locators.push(col);
+                    i += 8;
+                } else {
+                    panic!("How can a COL not have a vftable???")
+                }
+            } else {
+                i += 4;
+            }
+        } else {
+            i += 4;
+        }
+    }
+
+    // at this point, our RTTIClasses are only missing their CHD fields.
+    // but, we saved their addresses in classes_by_chd_exe_addr above.
+    // so parse them, and also parse BCAs/BCDs along the way.
+
+    // this lookup map here is because one BCD can be referenced by multiple BCAs,
+    // and we're not tryna make two BCDs with identical values;
+    // rather, just have the multiple BCAs point to the same BCD.
+    let mut bcds_by_exe_addr: BTreeMap<u32, Rc<BaseClassDescriptor>> = BTreeMap::new();
 
     Ok(true)
 }
-
-// fn find_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<bool> {
-//     // first, find the RTTI Type Descriptors
-//     find_rtti_type_descriptors(obj, rtti)?;
-//     // quick check - if there were 0 Type Descriptors found, RTTI isn't supported, bail early
-//     if rtti.type_descriptor_lookup.is_empty() {
-//         return Ok(false);
-//     }
-//     // then a few more sweeps to get the rest
-//     // first sweep: get BCDs and COLs in our lookups
-//     // our RTTIClasses will have CHD addresses, but they won't be analyzed yet
-//     find_bcds_and_cols(obj, rtti)?;
-//     // // second sweep: with our CHD addresses, create CHDs and BCAs for our lookups
-//     // find_chds_and_bcas(obj, rtti)?;
-//     // // last sweep: from the COLs we have, get the vftables
-//     // find_vftables(obj, rtti)?;
-//     Ok(true)
-// }
 
 pub struct FindRTTIObjectsXbox {}
 

--- a/src/analysis/rtti.rs
+++ b/src/analysis/rtti.rs
@@ -55,7 +55,7 @@ struct RTTIClass {
     pub name: String, // this class's name, inferred from the type descriptor
     pub type_descriptor_addr: u32, // type descriptor addr in the exe
     // Make this an Option because some RTTIClasses can legit just only have a Type Descriptor and nothing else
-    pub class_hierarchy_descriptor: Option<Rc<ClassHierarchyDescriptor>>,
+    pub class_hierarchy_descriptor: Option<Rc<ClassHierarchyDescriptor>>, // TODO: this could be a plain ole CHD? No Rc?
     // But, it can have multiple base classes, each with their own COL and vftable
     pub complete_object_locators: Vec<CompleteObjectLocator>,
     // TODO: add a field for base classes/direct bases when walking the inheritance tree
@@ -187,8 +187,7 @@ fn find_all_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<bool>
                 }
 
                 // search for col_start_addr in .rdata
-                let col_start_addr_bytes = col_start_addr.to_be_bytes();
-                if let Some(vftable_idx) = memmem::find(data, &col_start_addr_bytes) {
+                if let Some(vftable_idx) = memmem::find(data, &col_start_addr.to_be_bytes()) {
                     // the vftable is the next addr over from the COL, hence the +4
                     let vftable_addr = rdata_section.address as u32 + vftable_idx as u32 + 4;
 
@@ -234,6 +233,75 @@ fn find_all_rtti_structs(obj: &ObjInfo, rtti: &mut RTTIMetadata) -> Result<bool>
     // and we're not tryna make two BCDs with identical values;
     // rather, just have the multiple BCAs point to the same BCD.
     let mut bcds_by_exe_addr: BTreeMap<u32, Rc<BaseClassDescriptor>> = BTreeMap::new();
+
+    for (chd_exe_addr, the_rtti_class) in classes_by_chd_exe_addr {
+        log::debug!("CHD found at {:08X} for {}!", chd_exe_addr, the_rtti_class.borrow().name);
+        // navigate to the bytes in .rdata that make up this CHD, and parse it
+        let chd_data_idx = chd_exe_addr - rdata_section.address as u32;
+        let chd_data = &rdata_section.data[chd_data_idx as usize..chd_data_idx as usize + 16];
+        let mut chd = ClassHierarchyDescriptor {
+            addr: chd_exe_addr,
+            signature: u32::from_be_bytes(chd_data[0..4].try_into()?),
+            attributes: u32::from_be_bytes(chd_data[4..8].try_into()?),
+            num_base_classes: u32::from_be_bytes(chd_data[8..12].try_into()?),
+            base_class_array_addr: u32::from_be_bytes(chd_data[12..16].try_into()?),
+            base_class_descriptors: vec![],
+        };
+        assert_eq!(
+            chd.signature, 0,
+            "how on earth is this not zero: CHD signature, addr {:08X}",
+            chd_exe_addr
+        );
+        // if the recorded BCA addr is not within .rdata, something has gone horribly wrong
+        assert!(
+            rdata_section.address as u32 <= chd.base_class_array_addr
+                && chd.base_class_array_addr
+                    < rdata_section.address as u32 + rdata_section.size as u32,
+            "Bad BCA addr {:08X}!",
+            chd.base_class_array_addr
+        );
+        // parse the BCA and BCDs as well, since the CHD will own the BCA
+        let bca_data_idx = chd.base_class_array_addr - rdata_section.address as u32;
+        let bca_data = &rdata_section.data
+            [bca_data_idx as usize..bca_data_idx as usize + (chd.num_base_classes * 4) as usize];
+
+        for (_, chunk) in bca_data.chunks_exact(4).enumerate() {
+            let cur_bcd_addr = u32::from_be_bytes(chunk[0..4].try_into()?);
+            let cur_bcd = match bcds_by_exe_addr.entry(cur_bcd_addr) {
+                Entry::Vacant(entry) => {
+                    // it's vacant, parse and create a new BCD instance
+                    let bcd_data_idx = cur_bcd_addr - rdata_section.address as u32;
+                    let bcd_data =
+                        &rdata_section.data[bcd_data_idx as usize..bcd_data_idx as usize + 28];
+                    // assert that the type descriptor at data[0..4] corresponds to the_rtti_class
+                    let td_addr = u32::from_be_bytes(bcd_data[0..4].try_into()?);
+                    let Some(class_for_bcd) = classes_by_type_descriptor_exe_addr.get(&td_addr)
+                    else {
+                        panic!("Bad Type Descriptor addr {:08X}!", td_addr);
+                    };
+                    let bcd = BaseClassDescriptor {
+                        addr: cur_bcd_addr,
+                        num_contained_bases: u32::from_be_bytes(bcd_data[4..8].try_into()?),
+                        m_disp: i32::from_be_bytes(bcd_data[8..12].try_into()?),
+                        p_disp: i32::from_be_bytes(bcd_data[12..16].try_into()?),
+                        v_disp: i32::from_be_bytes(bcd_data[16..20].try_into()?),
+                        attributes: u32::from_be_bytes(bcd_data[20..24].try_into()?),
+                        owner: Rc::downgrade(&class_for_bcd),
+                    };
+                    let bcd_ptr = Rc::new(bcd);
+                    entry.insert(bcd_ptr.clone());
+                    bcd_ptr
+                }
+                Entry::Occupied(entry) => {
+                    // it's occupied, just use the one we've got
+                    entry.get().clone()
+                }
+            };
+            chd.base_class_descriptors.push(cur_bcd.clone());
+        }
+
+        the_rtti_class.borrow_mut().class_hierarchy_descriptor = Some(Rc::new(chd));
+    }
 
     Ok(true)
 }

--- a/src/analysis/rtti.rs
+++ b/src/analysis/rtti.rs
@@ -34,7 +34,6 @@ struct ClassHierarchyDescriptor {
     pub signature: u32,                                       // always 0
     pub attributes: u32, // bit 0 set = multiple inheritance, bit 1 set = virtual inheritance
     pub num_base_classes: u32, // number of entries in the Base Class Array
-    pub base_class_array_addr: u32, // BCA addr in the exe
     pub base_class_descriptors: Vec<Rc<BaseClassDescriptor>>, // the BCDs that make up the Base Class Array
 }
 
@@ -305,145 +304,153 @@ fn find_all_rtti_structs(
     // so, this will serve as an indicator for which CHDs have been fully parsed
     let mut parsed_chds_by_exe_addr: BTreeMap<u32, Rc<RefCell<RTTIClass>>> = BTreeMap::new();
 
-    // while classes_by_chd_exe_addr.len() != parsed_chds_by_exe_addr.len()?
-    for (chd_exe_addr, the_rtti_class) in &classes_by_chd_exe_addr {
-        // log::debug!("CHD found at {:08X} for {}!", chd_exe_addr, the_rtti_class.borrow().name);
-        // navigate to the bytes in .rdata that make up this CHD, and parse it
-        let chd_data_idx = chd_exe_addr - rdata_section.address as u32;
-        let chd_data = &rdata_section.data[chd_data_idx as usize..chd_data_idx as usize + 16];
-        let mut chd = ClassHierarchyDescriptor {
-            signature: u32::from_be_bytes(chd_data[0..4].try_into()?),
-            attributes: u32::from_be_bytes(chd_data[4..8].try_into()?),
-            num_base_classes: u32::from_be_bytes(chd_data[8..12].try_into()?),
-            base_class_array_addr: u32::from_be_bytes(chd_data[12..16].try_into()?),
-            base_class_descriptors: vec![],
-        };
-        assert_eq!(
-            chd.signature, 0,
-            "how on earth is this not zero: CHD signature, addr {:08X}",
-            chd_exe_addr
-        );
+    while classes_by_chd_exe_addr.len() != parsed_chds_by_exe_addr.len() {
+        let mut missed_chds: BTreeMap<u32, Rc<RefCell<RTTIClass>>> = BTreeMap::new();
+        for (chd_exe_addr, the_rtti_class) in &classes_by_chd_exe_addr {
+            // don't re-parse
+            if parsed_chds_by_exe_addr.contains_key(chd_exe_addr) {
+                continue;
+            }
 
-        // label the CHD here
-        state
-            .known_symbols
-            .entry(SectionAddress::new(rdata_sec_idx, chd_exe_addr.clone()))
-            .or_default()
-            .push(ObjSymbol {
-                // example:
-                // Type Descriptor class name (. omitted): ?AVFilePath@@
-                // Class Hierarchy Descriptor full symbol: ??_R3FilePath@@8
-                name: format!("??_R3{}8", the_rtti_class.borrow().name[3..].to_string()),
-                address: chd_exe_addr.clone() as u64,
-                section: Some(rdata_sec_idx),
-                size: 16,
-                size_known: true,
-                flags: ObjSymbolFlagSet(ObjSymbolFlags::Global.into()),
-                ..Default::default()
-            });
-
-        // if the recorded BCA addr is not within .rdata, something has gone horribly wrong
-        assert!(
-            rdata_section.address as u32 <= chd.base_class_array_addr
-                && chd.base_class_array_addr
-                    < rdata_section.address as u32 + rdata_section.size as u32,
-            "Bad BCA addr {:08X}!",
-            chd.base_class_array_addr
-        );
-
-        // label the BCA here
-        state
-            .known_symbols
-            .entry(SectionAddress::new(rdata_sec_idx, chd.base_class_array_addr))
-            .or_default()
-            .push(ObjSymbol {
-                // example:
-                // Type Descriptor class name (. omitted): ?AVFilePath@@
-                // Class Hierarchy Descriptor full symbol: ??_R2FilePath@@8
-                name: format!("??_R2{}8", the_rtti_class.borrow().name[3..].to_string()),
-                address: chd.base_class_array_addr as u64,
-                section: Some(rdata_sec_idx),
-                // there's a null word after the last BCD entry, hence the +1
-                size: ((chd.num_base_classes + 1) * 4) as u64,
-                size_known: true,
-                flags: ObjSymbolFlagSet(ObjSymbolFlags::Global.into()),
-                ..Default::default()
-            });
-
-        // parse the BCA and BCDs as well, since the CHD will own the BCA
-        let bca_data_idx = chd.base_class_array_addr - rdata_section.address as u32;
-        let bca_data = &rdata_section.data
-            [bca_data_idx as usize..bca_data_idx as usize + (chd.num_base_classes * 4) as usize];
-
-        for (_, chunk) in bca_data.chunks_exact(4).enumerate() {
-            let cur_bcd_addr = u32::from_be_bytes(chunk[0..4].try_into()?);
-            let cur_bcd = match bcds_by_exe_addr.entry(cur_bcd_addr) {
-                Entry::Vacant(entry) => {
-                    // it's vacant, parse and create a new BCD instance
-                    let bcd_data_idx = cur_bcd_addr - rdata_section.address as u32;
-                    let bcd_data =
-                        &rdata_section.data[bcd_data_idx as usize..bcd_data_idx as usize + 28];
-                    let td_addr = u32::from_be_bytes(bcd_data[0..4].try_into()?);
-                    let Some(class_for_bcd) = classes_by_type_descriptor_exe_addr.get(&td_addr)
-                    else {
-                        panic!("Bad Type Descriptor addr {:08X}!", td_addr);
-                    };
-                    let chd_addr = u32::from_be_bytes(bcd_data[24..28].try_into()?);
-                    if !classes_by_chd_exe_addr.contains_key(&chd_addr) {
-                        log::warn!(
-                            "Missing CHD addr {:08X} for {}!",
-                            chd_addr,
-                            class_for_bcd.borrow().name
-                        );
-                    }
-
-                    // FIXME: it is entirely possible that a new CHD can be discovered here,
-                    // due to an RTTI class not having any COLs, and thus, no CHD discovered at that point.
-                    // if a new CHD was discovered here, we need to parse it, plus its BCA
-                    // the BCDs i *believe* should already be discovered, but look just in case
-                    // see above map
-
-                    let bcd_ptr = Rc::new(BaseClassDescriptor {
-                        num_contained_bases: u32::from_be_bytes(bcd_data[4..8].try_into()?),
-                        m_disp: i32::from_be_bytes(bcd_data[8..12].try_into()?),
-                        p_disp: i32::from_be_bytes(bcd_data[12..16].try_into()?),
-                        v_disp: i32::from_be_bytes(bcd_data[16..20].try_into()?),
-                        attributes: u32::from_be_bytes(bcd_data[20..24].try_into()?),
-                        owner: Rc::downgrade(&class_for_bcd),
-                    });
-                    // label the BCD here
-                    state
-                        .known_symbols
-                        .entry(SectionAddress::new(rdata_sec_idx, cur_bcd_addr))
-                        .or_default()
-                        .push(ObjSymbol {
-                            name: format!(
-                                "??_R1{}{}{}{}{}8",
-                                encode_num(bcd_ptr.m_disp),
-                                encode_num(bcd_ptr.p_disp),
-                                encode_num(bcd_ptr.v_disp),
-                                encode_num(bcd_ptr.attributes as i32),
-                                class_for_bcd.borrow().name[3..].to_string()
-                            ),
-                            address: cur_bcd_addr as u64,
-                            section: Some(rdata_sec_idx),
-                            size: 28,
-                            size_known: true,
-                            flags: ObjSymbolFlagSet(ObjSymbolFlags::Global.into()),
-                            ..Default::default()
-                        });
-                    entry.insert(bcd_ptr.clone());
-                    bcd_ptr
-                }
-                Entry::Occupied(entry) => {
-                    // it's occupied, just use the one we've got
-                    entry.get().clone()
-                }
+            // log::debug!("CHD found at {:08X} for {}!", chd_exe_addr, the_rtti_class.borrow().name);
+            // navigate to the bytes in .rdata that make up this CHD, and parse it
+            let chd_data_idx = chd_exe_addr - rdata_section.address as u32;
+            let chd_data = &rdata_section.data[chd_data_idx as usize..chd_data_idx as usize + 16];
+            let mut chd = ClassHierarchyDescriptor {
+                signature: u32::from_be_bytes(chd_data[0..4].try_into()?),
+                attributes: u32::from_be_bytes(chd_data[4..8].try_into()?),
+                num_base_classes: u32::from_be_bytes(chd_data[8..12].try_into()?),
+                base_class_descriptors: vec![],
             };
-            chd.base_class_descriptors.push(cur_bcd.clone());
-        }
+            assert_eq!(
+                chd.signature, 0,
+                "how on earth is this not zero: CHD signature, addr {:08X}",
+                chd_exe_addr
+            );
 
-        the_rtti_class.borrow_mut().class_hierarchy_descriptor = Some(chd);
+            let base_class_array_addr = u32::from_be_bytes(chd_data[12..16].try_into()?);
+
+            // label the CHD here
+            state
+                .known_symbols
+                .entry(SectionAddress::new(rdata_sec_idx, *chd_exe_addr))
+                .or_default()
+                .push(ObjSymbol {
+                    // example:
+                    // Type Descriptor class name (. omitted): ?AVFilePath@@
+                    // Class Hierarchy Descriptor full symbol: ??_R3FilePath@@8
+                    name: format!("??_R3{}8", the_rtti_class.borrow().name[3..].to_string()),
+                    address: *chd_exe_addr as u64,
+                    section: Some(rdata_sec_idx),
+                    size: 16,
+                    size_known: true,
+                    flags: ObjSymbolFlagSet(ObjSymbolFlags::Global.into()),
+                    ..Default::default()
+                });
+
+            // if the recorded BCA addr is not within .rdata, something has gone horribly wrong
+            assert!(
+                rdata_section.address as u32 <= base_class_array_addr
+                    && base_class_array_addr
+                        < rdata_section.address as u32 + rdata_section.size as u32,
+                "Bad BCA addr {:08X}!",
+                base_class_array_addr
+            );
+
+            // label the BCA here
+            state
+                .known_symbols
+                .entry(SectionAddress::new(rdata_sec_idx, base_class_array_addr))
+                .or_default()
+                .push(ObjSymbol {
+                    // example:
+                    // Type Descriptor class name (. omitted): ?AVFilePath@@
+                    // Class Hierarchy Descriptor full symbol: ??_R2FilePath@@8
+                    name: format!("??_R2{}8", the_rtti_class.borrow().name[3..].to_string()),
+                    address: base_class_array_addr as u64,
+                    section: Some(rdata_sec_idx),
+                    // there's a null word after the last BCD entry, hence the +1
+                    size: ((chd.num_base_classes + 1) * 4) as u64,
+                    size_known: true,
+                    flags: ObjSymbolFlagSet(ObjSymbolFlags::Global.into()),
+                    ..Default::default()
+                });
+
+            // parse the BCA and BCDs as well, since the CHD will own the BCA
+            let bca_data_idx = base_class_array_addr - rdata_section.address as u32;
+            let bca_data = &rdata_section.data[bca_data_idx as usize
+                ..bca_data_idx as usize + (chd.num_base_classes * 4) as usize];
+
+            for (_, chunk) in bca_data.chunks_exact(4).enumerate() {
+                let cur_bcd_addr = u32::from_be_bytes(chunk[0..4].try_into()?);
+                let cur_bcd = match bcds_by_exe_addr.entry(cur_bcd_addr) {
+                    Entry::Vacant(entry) => {
+                        // it's vacant, parse and create a new BCD instance
+                        let bcd_data_idx = cur_bcd_addr - rdata_section.address as u32;
+                        let bcd_data =
+                            &rdata_section.data[bcd_data_idx as usize..bcd_data_idx as usize + 28];
+                        let td_addr = u32::from_be_bytes(bcd_data[0..4].try_into()?);
+                        let Some(class_for_bcd) = classes_by_type_descriptor_exe_addr.get(&td_addr)
+                        else {
+                            panic!("Bad Type Descriptor addr {:08X}!", td_addr);
+                        };
+                        let chd_addr = u32::from_be_bytes(bcd_data[24..28].try_into()?);
+                        if !classes_by_chd_exe_addr.contains_key(&chd_addr) {
+                            // log::warn!(
+                            //     "Missing CHD addr {:08X} for {}!",
+                            //     chd_addr,
+                            //     class_for_bcd.borrow().name
+                            // );
+                            // if we don't have it marked as missed, add it in
+                            missed_chds.entry(chd_addr).or_insert_with(|| class_for_bcd.clone());
+                        }
+
+                        let bcd_ptr = Rc::new(BaseClassDescriptor {
+                            num_contained_bases: u32::from_be_bytes(bcd_data[4..8].try_into()?),
+                            m_disp: i32::from_be_bytes(bcd_data[8..12].try_into()?),
+                            p_disp: i32::from_be_bytes(bcd_data[12..16].try_into()?),
+                            v_disp: i32::from_be_bytes(bcd_data[16..20].try_into()?),
+                            attributes: u32::from_be_bytes(bcd_data[20..24].try_into()?),
+                            owner: Rc::downgrade(&class_for_bcd),
+                        });
+                        // label the BCD here
+                        state
+                            .known_symbols
+                            .entry(SectionAddress::new(rdata_sec_idx, cur_bcd_addr))
+                            .or_default()
+                            .push(ObjSymbol {
+                                name: format!(
+                                    "??_R1{}{}{}{}{}8",
+                                    encode_num(bcd_ptr.m_disp),
+                                    encode_num(bcd_ptr.p_disp),
+                                    encode_num(bcd_ptr.v_disp),
+                                    encode_num(bcd_ptr.attributes as i32),
+                                    class_for_bcd.borrow().name[3..].to_string()
+                                ),
+                                address: cur_bcd_addr as u64,
+                                section: Some(rdata_sec_idx),
+                                size: 28,
+                                size_known: true,
+                                flags: ObjSymbolFlagSet(ObjSymbolFlags::Global.into()),
+                                ..Default::default()
+                            });
+                        entry.insert(bcd_ptr.clone());
+                        bcd_ptr
+                    }
+                    Entry::Occupied(entry) => {
+                        // it's occupied, just use the one we've got
+                        entry.get().clone()
+                    }
+                };
+                chd.base_class_descriptors.push(cur_bcd.clone());
+            }
+
+            the_rtti_class.borrow_mut().class_hierarchy_descriptor = Some(chd);
+            parsed_chds_by_exe_addr.insert(*chd_exe_addr, the_rtti_class.clone());
+        }
+        let old_len = classes_by_chd_exe_addr.len();
+        classes_by_chd_exe_addr.append(&mut missed_chds);
+        assert!(classes_by_chd_exe_addr.len() >= old_len, "Unbreakable loop while parsing CHDs!");
     }
 
     Ok(true)
@@ -474,8 +481,12 @@ fn compute_superclass_info(
         let mut c = rc.borrow_mut();
         if let Some(chd) = &c.class_hierarchy_descriptor {
             // do the superclass analysis
+            // 0 COLs/vftables - still record info/mark anything down here? not sure yet
+            if c.complete_object_locators.len() == 0 {
+                log::debug!("0 COL RTTI Object {}", c.name);
+            }
             // 1 COL/vftable = zero virtual inheritance, easiest case to deal with rn
-            if c.complete_object_locators.len() == 1 {
+            else if c.complete_object_locators.len() == 1 {
                 log::debug!("1 COL RTTI Object {}", c.name);
                 let the_sole_col = &c.complete_object_locators[0];
                 // make a label for the COL, and for the vftable

--- a/src/analysis/rtti.rs
+++ b/src/analysis/rtti.rs
@@ -300,7 +300,13 @@ fn find_all_rtti_structs(
     // rather, just have the multiple BCAs point to the same BCD.
     let mut bcds_by_exe_addr: BTreeMap<u32, Rc<BaseClassDescriptor>> = BTreeMap::new();
 
-    for (chd_exe_addr, the_rtti_class) in classes_by_chd_exe_addr {
+    // it is entirely possible that a new CHD can be discovered while populating other CHDs,
+    // due to an RTTI class not having any COLs, and thus, no CHD discovered at that point.
+    // so, this will serve as an indicator for which CHDs have been fully parsed
+    let mut parsed_chds_by_exe_addr: BTreeMap<u32, Rc<RefCell<RTTIClass>>> = BTreeMap::new();
+
+    // while classes_by_chd_exe_addr.len() != parsed_chds_by_exe_addr.len()?
+    for (chd_exe_addr, the_rtti_class) in &classes_by_chd_exe_addr {
         // log::debug!("CHD found at {:08X} for {}!", chd_exe_addr, the_rtti_class.borrow().name);
         // navigate to the bytes in .rdata that make up this CHD, and parse it
         let chd_data_idx = chd_exe_addr - rdata_section.address as u32;
@@ -321,14 +327,14 @@ fn find_all_rtti_structs(
         // label the CHD here
         state
             .known_symbols
-            .entry(SectionAddress::new(rdata_sec_idx, chd_exe_addr))
+            .entry(SectionAddress::new(rdata_sec_idx, chd_exe_addr.clone()))
             .or_default()
             .push(ObjSymbol {
                 // example:
                 // Type Descriptor class name (. omitted): ?AVFilePath@@
                 // Class Hierarchy Descriptor full symbol: ??_R3FilePath@@8
                 name: format!("??_R3{}8", the_rtti_class.borrow().name[3..].to_string()),
-                address: chd_exe_addr as u64,
+                address: chd_exe_addr.clone() as u64,
                 section: Some(rdata_sec_idx),
                 size: 16,
                 size_known: true,
@@ -382,6 +388,21 @@ fn find_all_rtti_structs(
                     else {
                         panic!("Bad Type Descriptor addr {:08X}!", td_addr);
                     };
+                    let chd_addr = u32::from_be_bytes(bcd_data[24..28].try_into()?);
+                    if !classes_by_chd_exe_addr.contains_key(&chd_addr) {
+                        log::warn!(
+                            "Missing CHD addr {:08X} for {}!",
+                            chd_addr,
+                            class_for_bcd.borrow().name
+                        );
+                    }
+
+                    // FIXME: it is entirely possible that a new CHD can be discovered here,
+                    // due to an RTTI class not having any COLs, and thus, no CHD discovered at that point.
+                    // if a new CHD was discovered here, we need to parse it, plus its BCA
+                    // the BCDs i *believe* should already be discovered, but look just in case
+                    // see above map
+
                     let bcd_ptr = Rc::new(BaseClassDescriptor {
                         num_contained_bases: u32::from_be_bytes(bcd_data[4..8].try_into()?),
                         m_disp: i32::from_be_bytes(bcd_data[8..12].try_into()?),
@@ -428,6 +449,73 @@ fn find_all_rtti_structs(
     Ok(true)
 }
 
+fn compute_superclass_info(
+    state: &mut AnalyzerState,
+    obj: &ObjInfo,
+    rtti: &mut RTTIMetadata,
+) -> Result<()> {
+    let (rdata_sec_idx, _) = obj.sections.by_name(".rdata")?.expect("No .rdata section!");
+
+    // the original impl had us walking through each RTTI object and getting direct bases
+    // but, since we have direct access to the BCAs now, this isn't necessary, we can just...do that on the fly
+
+    // so, let's sort the RTTIClasses by smallest amount of COLs, and then smallest number of BCA entries (0 if no BCA)
+    rtti.discovered_classes.sort_by_key(|rc| {
+        let c = rc.borrow();
+        let bca_len = match &c.class_hierarchy_descriptor {
+            Some(chd) => chd.num_base_classes,
+            None => 0,
+        };
+        (c.complete_object_locators.len(), bca_len)
+    });
+
+    for rc in &rtti.discovered_classes {
+        // get the underlying RTTIClass from the Rc
+        let mut c = rc.borrow_mut();
+        if let Some(chd) = &c.class_hierarchy_descriptor {
+            // do the superclass analysis
+            // 1 COL/vftable = zero virtual inheritance, easiest case to deal with rn
+            if c.complete_object_locators.len() == 1 {
+                log::debug!("1 COL RTTI Object {}", c.name);
+                let the_sole_col = &c.complete_object_locators[0];
+                // make a label for the COL, and for the vftable
+                state
+                    .known_symbols
+                    .entry(SectionAddress::new(rdata_sec_idx, the_sole_col.addr))
+                    .or_default()
+                    .push(ObjSymbol {
+                        name: format!("??_R4{}6B@", c.name[3..].to_string()),
+                        address: the_sole_col.addr as u64,
+                        section: Some(rdata_sec_idx),
+                        size: 20,
+                        size_known: true,
+                        flags: ObjSymbolFlagSet(ObjSymbolFlags::Global.into()),
+                        ..Default::default()
+                    });
+                state
+                    .known_symbols
+                    .entry(SectionAddress::new(rdata_sec_idx, the_sole_col.vftable_addr))
+                    .or_default()
+                    .push(ObjSymbol {
+                        name: format!("??_7{}6B@", c.name[3..].to_string()),
+                        address: the_sole_col.vftable_addr as u64,
+                        section: Some(rdata_sec_idx),
+                        size: (the_sole_col.num_vftable_entries * 4) as u64,
+                        size_known: true,
+                        flags: ObjSymbolFlagSet(ObjSymbolFlags::Global.into()),
+                        ..Default::default()
+                    });
+            }
+            // nightmare territory - 2+ COLs
+            else {
+                // TODO: walk the inheritance tree and deduce superclass info for the final labels
+            }
+        }
+    }
+
+    Ok(())
+}
+
 pub struct FindRTTIObjectsXbox {}
 
 impl AnalysisPass for FindRTTIObjectsXbox {
@@ -444,6 +532,7 @@ impl AnalysisPass for FindRTTIObjectsXbox {
         // if we've reached this point, we have a full set of RTTI objects and their relationships
         // and everything except for COLs and vftables have been labeled
         // so, compute superclass information to get the remaining context needed to label those
+        compute_superclass_info(state, obj, &mut rtti_metadata)?;
 
         Ok(())
     }

--- a/src/cmd/xex.rs
+++ b/src/cmd/xex.rs
@@ -25,7 +25,7 @@ use crate::{
         cfa::{AnalyzerState, SectionAddress},
         objects::{detect_objects, detect_strings},
         pass::{AnalysisPass, FindSaveRestSledsXbox},
-        rtti::detect_rtti,
+        rtti::FindRTTIObjectsXbox,
         tracker::Tracker,
     },
     cmd::dol::{
@@ -254,8 +254,6 @@ fn split_write_obj_exe(
         debug!("Detecting strings");
         detect_strings(&mut module.obj)?;
     }
-
-    detect_rtti(&mut module.obj)?;
 
     debug!("Adjusting splits");
     let module_id = module.obj.module_id;
@@ -571,6 +569,7 @@ fn load_analyze_xex(config: &ProjectConfig) -> Result<ExeAnalyzeResult> {
         let mut state = AnalyzerState::default();
         debug!("Detecting function boundaries");
         FindSaveRestSledsXbox::execute(&mut state, &obj)?;
+        FindRTTIObjectsXbox::execute(&mut state, &obj)?;
         state.detect_functions(&obj)?; // perform CFA
         state.apply(&mut obj)?; // give each found function a symbol
     }
@@ -621,6 +620,7 @@ fn disasm(args: DisasmArgs) -> Result<()> {
     // step 2. find common functions (save/restore reg funcs, XAPI calls)
     // rename the save/restore gpr/fpr funcs that were previously found in pdata
     FindSaveRestSledsXbox::execute(&mut state, &obj)?;
+    FindRTTIObjectsXbox::execute(&mut state, &obj)?;
 
     state.detect_functions(&obj)?;
     log::info!(
@@ -643,8 +643,6 @@ fn disasm(args: DisasmArgs) -> Result<()> {
 
     println!("Detecting strings");
     detect_strings(&mut obj)?;
-
-    detect_rtti(&mut obj)?;
 
     // println!("Writing symbols.txt");
     // let mut w = buf_writer(&args.out)?;

--- a/src/obj/mod.rs
+++ b/src/obj/mod.rs
@@ -53,8 +53,8 @@ pub struct ObjInfo {
     pub name: String,
     pub symbols: ObjSymbols,
     pub sections: ObjSections,
+    // The entry point of the executable
     pub entry: Option<u64>,
-    pub rtti: bool,
 
     // Linker generated
     pub sda2_base: Option<u32>,
@@ -94,7 +94,6 @@ impl ObjInfo {
             symbols: ObjSymbols::new(kind, symbols),
             sections: ObjSections::new(kind, sections),
             entry: None,
-            rtti: false,
             sda2_base: None,
             sda_base: None,
             stack_address: None,

--- a/src/util/map.rs
+++ b/src/util/map.rs
@@ -929,7 +929,6 @@ pub fn create_obj(result: &MapInfo) -> Result<ObjInfo> {
         symbols: ObjSymbols::new(ObjKind::Executable, vec![]),
         sections: ObjSections::new(ObjKind::Executable, sections),
         entry: None, // TODO result.entry_point
-        rtti: false,
         sda2_base: None,
         sda_base: None,
         stack_address: None,

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -8,6 +8,7 @@ pub mod diff;
 pub mod file;
 pub mod map;
 pub mod map_exe;
+pub mod msvc;
 pub mod nested;
 pub mod nlzss;
 pub mod path;

--- a/src/util/msvc.rs
+++ b/src/util/msvc.rs
@@ -1,0 +1,32 @@
+// i had to steal this from LLVM's MicrosoftCXXNameMangler::mangleNumber and mangleBits
+pub fn encode_num(num: i32) -> String {
+    // <non-negative integer> ::= A@              # when Number == 0
+    //                        ::= <decimal digit> # when 1 <= Number <= 10
+    //                        ::= <hex digit>+ @  # when Number >= 10
+    // <number>               ::= [?] <non-negative integer>
+    let mut ret = String::new();
+    let mut eval = num;
+    if eval < 0 {
+        eval = -eval;
+        ret.push('?');
+    }
+    if eval == 0 {
+        ret.push_str("A@");
+    } else if eval >= 1 && eval <= 10 {
+        ret += &*(eval - 1).to_string();
+    } else {
+        let mut digits = Vec::new();
+        let mut value = eval as u32;
+        while value != 0 {
+            let nibble = (value & 0xF) as u8;
+            digits.push((b'A' + nibble) as char);
+            value >>= 4;
+        }
+        digits.reverse();
+        for ch in digits {
+            ret.push(ch);
+        }
+        ret.push('@');
+    }
+    ret
+}


### PR DESCRIPTION
RTTI labeling now happens before CFA, which gives us more control over the symbol sizes/scopes.
Because we now walk through vftables, this provides more function start addresses for CFA to go off of.

Still single inheritance labeling only, multiple/virtual inheritance (where there can be multiple COLs/vftables) is still hard