### PR TITLE
Adjust jump table logic

### DIFF
--- a/src/analysis/cfa.rs
+++ b/src/analysis/cfa.rs
@@ -491,19 +491,6 @@ impl AnalyzerState {
                 }
                 self.jump_tables
                     .append(&mut slices.jump_table_references.clone());
-                for label in slices.special_jump_table_labels.iter() {
-                    self.known_symbols
-                        .entry(*label)
-                        .or_default()
-                        .push(ObjSymbol {
-                            name: format!("$LN{:X}", label.address),
-                            address: label.address,
-                            section: Some(label.section),
-                            size_known: true,
-                            flags: ObjSymbolFlagSet(ObjSymbolFlags::Global.into()),
-                            ..Default::default()
-                        })
-                }
                 let end = slices.end();
                 let info = self.functions.get_mut(&addr).unwrap();
                 info.analyzed = true;
@@ -552,19 +539,7 @@ impl AnalyzerState {
                 }
                 self.jump_tables
                     .append(&mut slices.jump_table_references.clone());
-                for label in slices.special_jump_table_labels.iter() {
-                    self.known_symbols
-                        .entry(*label)
-                        .or_default()
-                        .push(ObjSymbol {
-                            name: format!("$LN{:X}", label.address),
-                            address: label.address,
-                            section: Some(label.section),
-                            flags: ObjSymbolFlagSet(ObjSymbolFlags::Global.into()),
-                            ..Default::default()
-                        })
-                }
-                for label in slices.special_catch_labels.iter() {
+                for label in slices.special_ln_labels.iter() {
                     self.known_symbols
                         .entry(*label)
                         .or_default()

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -86,7 +86,7 @@ pub fn relocation_target_for(
     read_relocation_address(obj, section, addr.address, reloc_kind)
 }
 
-fn get_jump_table_entries(
+fn get_jump_table_entries_impl(
     obj: &ObjInfo,
     addr: SectionAddress, // the address the jump table is at
     jump_table_type: JumpTableType,
@@ -317,6 +317,33 @@ fn get_jump_table_entries(
     }
 }
 
+// Returns a Vec of every found jump table entry and its size, instead of unique entries like previous iterations.
+// This is because for absolute jump tables, we need to add Absolute relocs for each entry.
+// If you just need the unique entries, call BTreeSet::from_iter.
+pub fn get_jump_table_entries(
+    obj: &ObjInfo,
+    addr: SectionAddress, // the address the jump table is at
+    jump_table_type: JumpTableType,
+    size: Option<NonZeroU32>,
+    from: SectionAddress, // the address of the bctr that uses the jump table
+    function_start: SectionAddress,
+    function_end: Option<SectionAddress>,
+) -> Result<(Vec<SectionAddress>, u32)> {
+    if !is_valid_jump_table_addr(obj, addr, jump_table_type) {
+        return Ok((Vec::new(), 0));
+    }
+    get_jump_table_entries_impl(
+        obj,
+        addr,
+        jump_table_type,
+        size,
+        from,
+        function_start,
+        function_end,
+    )
+    .with_context(|| format!("While fetching jump table entries starting at {addr:#010X}"))
+}
+
 pub fn uniq_jump_table_entries(
     obj: &ObjInfo,
     addr: SectionAddress, // the address the jump table is at
@@ -329,7 +356,7 @@ pub fn uniq_jump_table_entries(
     if !is_valid_jump_table_addr(obj, addr, jump_table_type) {
         return Ok((BTreeSet::new(), 0));
     }
-    let (entries, size) = get_jump_table_entries(
+    let (entries, size) = get_jump_table_entries_impl(
         obj,
         addr,
         jump_table_type,

--- a/src/analysis/slices.rs
+++ b/src/analysis/slices.rs
@@ -12,7 +12,7 @@ use crate::{
         cfa::{FunctionInfo, SectionAddress},
         disassemble,
         executor::{ExecCbData, ExecCbResult, Executor},
-        uniq_jump_table_entries,
+        get_jump_table_entries,
         vm::{BranchTarget, GprValue, StepResult, VM, section_address_for},
     },
     obj::{ObjInfo, ObjKind, ObjSection, ObjSymbolKind},
@@ -415,7 +415,8 @@ impl FunctionSlices {
                         address,
                         size
                     );
-                    let (entries, size) = uniq_jump_table_entries(
+
+                    let (entries, size) = get_jump_table_entries(
                         obj,
                         address,
                         jt,
@@ -424,7 +425,10 @@ impl FunctionSlices {
                         function_start,
                         function_end.or_else(|| self.end()),
                     )?;
+                    let entries = BTreeSet::from_iter(entries);
                     log::debug!("-> size {}: {:?}", size, entries);
+
+                    // what if jump table is absolute? do something different here?
 
                     // if this function has a known end, check that every jump table entry is within function bounds
                     let within_func_bounds = match function_end {

--- a/src/analysis/slices.rs
+++ b/src/analysis/slices.rs
@@ -428,6 +428,13 @@ impl FunctionSlices {
                     let entries = BTreeSet::from_iter(entries);
                     log::debug!("-> size {}: {:?}", size, entries);
 
+                    // Absolute jump tables need LNs for every unique entry
+                    if matches!(jt, JumpTableType::Absolute) {
+                        for entry in &entries {
+                            self.special_ln_labels.push(*entry);
+                        }
+                    }
+
                     // if this function has a known end, check that every jump table entry is within function bounds
                     let within_func_bounds = match function_end {
                         Some(end) => !entries

--- a/src/analysis/slices.rs
+++ b/src/analysis/slices.rs
@@ -13,7 +13,7 @@ use crate::{
         disassemble,
         executor::{ExecCbData, ExecCbResult, Executor},
         get_jump_table_entries,
-        vm::{BranchTarget, GprValue, StepResult, VM, section_address_for},
+        vm::{BranchTarget, GprValue, JumpTableType, StepResult, VM, section_address_for},
     },
     obj::{ObjInfo, ObjKind, ObjSection, ObjSymbolKind},
 };
@@ -24,8 +24,8 @@ pub struct FunctionSlices {
     pub branches: BTreeMap<SectionAddress, Vec<SectionAddress>>,
     pub function_references: BTreeSet<SectionAddress>,
     pub jump_table_references: BTreeMap<SectionAddress, u32>,
-    pub special_jump_table_labels: Vec<SectionAddress>,
-    pub special_catch_labels: Vec<SectionAddress>,
+    // Addresses where we need to add an $LN label
+    pub special_ln_labels: Vec<SectionAddress>,
     pub prologue: Option<SectionAddress>,
     pub epilogue: Option<SectionAddress>,
     // Either a block or tail call
@@ -296,7 +296,7 @@ impl FunctionSlices {
                     .take(cxx_eh_func_info.num_tries as usize)
                 {
                     if maybe_catch_ln < catch_addr.address {
-                        self.special_catch_labels
+                        self.special_ln_labels
                             .push(SectionAddress::new(function_start.section, maybe_catch_ln));
                         break;
                     }
@@ -428,8 +428,6 @@ impl FunctionSlices {
                     let entries = BTreeSet::from_iter(entries);
                     log::debug!("-> size {}: {:?}", size, entries);
 
-                    // what if jump table is absolute? do something different here?
-
                     // if this function has a known end, check that every jump table entry is within function bounds
                     let within_func_bounds = match function_end {
                         Some(end) => !entries
@@ -441,18 +439,20 @@ impl FunctionSlices {
                     // this if statements is true if:
                     // the next_address is in our jump table entries OR next_address marks the start of one our established blocks
                     // OR we're within known func bounds
+                    // OR this is an absolute jump table type
                     // AND
                     // none of our jump table entries are known function starts
                     if (entries.contains(&next_address)
                         || self.blocks.contains_key(&next_address)
-                        || within_func_bounds)
+                        || within_func_bounds
+                        || matches!(jt, JumpTableType::Absolute))
                         && !entries.iter().any(|&addr| {
                             self.is_known_function(known_functions, addr)
                                 .is_some_and(|fn_addr| fn_addr != function_start)
                         })
                     {
                         self.jump_table_references.insert(address, size);
-                        self.special_jump_table_labels.push(ins_addr + 4);
+                        self.special_ln_labels.push(ins_addr + 4);
                         let mut branches = vec![];
                         for addr in entries {
                             branches.push(addr);

--- a/src/analysis/tracker.rs
+++ b/src/analysis/tracker.rs
@@ -14,7 +14,7 @@ use crate::{
         cfa::SectionAddress,
         executor::{ExecCbData, ExecCbResult, Executor},
         get_jump_table_entries, read_u32, relocation_target_for,
-        vm::{BranchTarget, GprValue, StepResult, VM},
+        vm::{BranchTarget, GprValue, JumpTableType, StepResult, VM},
     },
     obj::{
         ObjDataKind, ObjInfo, ObjKind, ObjReloc, ObjRelocKind, ObjSection, ObjSectionKind,
@@ -381,7 +381,17 @@ impl Tracker {
                         function_start,
                         Some(function_end),
                     )?;
-                    // TODO: if this is an absolute jump table, add relocs for each entry
+                    // if this is an absolute jump table, add relocs for each entry
+                    if matches!(jt, JumpTableType::Absolute) {
+                        let mut offset = 0;
+                        for entry in &entries {
+                            self.relocations.insert(
+                                address + offset,
+                                Relocation::Absolute(RelocationTarget::Address(*entry)),
+                            );
+                            offset += 4;
+                        }
+                    }
                     for target in BTreeSet::from_iter(entries) {
                         if is_function_addr(target) {
                             executor.push(target, vm.clone_all(), true);
@@ -433,6 +443,17 @@ impl Tracker {
                                 function_start,
                                 Some(function_end),
                             )?;
+                            // if this is an absolute jump table, add relocs for each entry
+                            if matches!(jt, JumpTableType::Absolute) {
+                                let mut offset = 0;
+                                for entry in &entries {
+                                    self.relocations.insert(
+                                        address + offset,
+                                        Relocation::Absolute(RelocationTarget::Address(*entry)),
+                                    );
+                                    offset += 4;
+                                }
+                            }
                             for target in BTreeSet::from_iter(entries) {
                                 if is_function_addr(target) {
                                     executor.push(target, branch.vm.clone_all(), true);

--- a/src/analysis/tracker.rs
+++ b/src/analysis/tracker.rs
@@ -13,7 +13,7 @@ use crate::{
         RelocationTarget,
         cfa::SectionAddress,
         executor::{ExecCbData, ExecCbResult, Executor},
-        read_u32, relocation_target_for, uniq_jump_table_entries,
+        get_jump_table_entries, read_u32, relocation_target_for,
         vm::{BranchTarget, GprValue, StepResult, VM},
     },
     obj::{
@@ -372,7 +372,7 @@ impl Tracker {
                     jump_table_address: RelocationTarget::Address(address),
                     size,
                 } => {
-                    let (entries, _) = uniq_jump_table_entries(
+                    let (entries, _) = get_jump_table_entries(
                         obj,
                         address,
                         jt,
@@ -382,7 +382,7 @@ impl Tracker {
                         Some(function_end),
                     )?;
                     // TODO: if this is an absolute jump table, add relocs for each entry
-                    for target in entries {
+                    for target in BTreeSet::from_iter(entries) {
                         if is_function_addr(target) {
                             executor.push(target, vm.clone_all(), true);
                         }
@@ -424,7 +424,7 @@ impl Tracker {
                             jump_table_address: RelocationTarget::Address(address),
                             size,
                         } => {
-                            let (entries, _) = uniq_jump_table_entries(
+                            let (entries, _) = get_jump_table_entries(
                                 obj,
                                 address,
                                 jt,
@@ -433,7 +433,7 @@ impl Tracker {
                                 function_start,
                                 Some(function_end),
                             )?;
-                            for target in entries {
+                            for target in BTreeSet::from_iter(entries) {
                                 if is_function_addr(target) {
                                     executor.push(target, branch.vm.clone_all(), true);
                                 }


### PR DESCRIPTION
Better support for absolute jump tables, so objdiff should pick them up now instead of a series of fake lwzs